### PR TITLE
Change mobs to override getAmbientSound, getHurtSound, getDeathSound for sounds

### DIFF
--- a/main/java/net/journey/JourneyItems.java
+++ b/main/java/net/journey/JourneyItems.java
@@ -1354,7 +1354,8 @@ public class JourneyItems {
 		rockyHammer = new ItemHammer("rockyHammer", "Rocky Hammer", JourneyToolMaterial.ROCKY_HAMMER, false, EntityRock.class, 6, 4, 2230);
 		crystalizedHammer = new ItemHammer("crystalizedHammer", "Crystalized Hammer", JourneyToolMaterial.CRYSTAL_HAMMER, false, EntityIceBall.class, 7, 4, 3320);
 
-		//chaosCannon = new ItemGun("chaosCannon", "Chaos Cannon", 6, "Shoots a bouncing projectile", null);
+		//Use to test essence
+		chaosCannon = new ItemGun("chaosCannon", "Chaos Cannon", 6, "Shoots a bouncing projectile", null);
 		//rockLauncher = new ItemGun("rockLauncher", "Rock Launcher", 4, "Stuns mobs for 10 seconds", EntityRock.class);
 		//netherPlasma = new ItemGun("netherPlasma", "Nether Plasma", 10, "Burns mobs for 10 seconds", EntityNetherPlasma.class);
 		//oceanPlasma = new ItemGun("oceanPlasma", "Ocean Plasma", 4, "Harms mobs", EntityFloroWater.class);

--- a/main/java/net/journey/client/server/BarTickHandler.java
+++ b/main/java/net/journey/client/server/BarTickHandler.java
@@ -1,5 +1,6 @@
 package net.journey.client.server;
 
+import org.lwjgl.opengl.Display;
 import org.lwjgl.opengl.GL11;
 
 import net.minecraft.client.Minecraft;

--- a/main/java/net/journey/entity/EntityPeacefullMob.java
+++ b/main/java/net/journey/entity/EntityPeacefullMob.java
@@ -75,7 +75,7 @@ public abstract class EntityPeacefullMob extends EntityCreature implements IMob 
 	public abstract SoundEvent setLivingSound();
 	public abstract SoundEvent setHurtSound();
 	public abstract SoundEvent setDeathSound();
-	public abstract Item getItemDropped();
+	public abstract Item getDropItem();
 
 	@Override
 	public void onLivingUpdate() {
@@ -88,14 +88,9 @@ public abstract class EntityPeacefullMob extends EntityCreature implements IMob 
 	}
 
 	@Override
-	protected Item getDropItem() {
-		return getItemDropped();
-	}
-
-	@Override
 	protected void dropFewItems(boolean b, int j) {
 		for(int i = 0; i < 1 + rand.nextInt(1); i++)
-			this.dropItem(getItemDropped(), 1);
+			this.dropItem(getDropItem(), 1);
 	}
 	
 	@Override

--- a/main/java/net/journey/entity/mob/boiling/EntityBurningLight.java
+++ b/main/java/net/journey/entity/mob/boiling/EntityBurningLight.java
@@ -37,17 +37,17 @@ public class EntityBurningLight extends EntityModMob{
 	}
 	
 	@Override
-	public SoundEvent setLivingSound() {
+	public SoundEvent getAmbientSound() {
 		return SoundEvents.ENTITY_BLAZE_AMBIENT;
 	}
 
 	@Override
-	public SoundEvent setHurtSound() {
+	public SoundEvent getHurtSound(DamageSource sourceIn) {
 		return SoundEvents.ENTITY_BLAZE_HURT;
 	}
 
 	@Override
-	public SoundEvent setDeathSound() {
+	public SoundEvent getDeathSound() {
 		return SoundEvents.ENTITY_BLAZE_DEATH;
 	}
 	
@@ -74,7 +74,7 @@ public class EntityBurningLight extends EntityModMob{
 	}
 	
 	@Override
-	public Item getItemDropped() {
+	public Item getDropItem() {
 		return null;
 	}
 	
@@ -85,7 +85,7 @@ public class EntityBurningLight extends EntityModMob{
 	
 	@Override
 	protected void dropFewItems(boolean b, int j) {
-		Item it = getItemDropped();
+		Item it = getDropItem();
 		this.dropItem(it, 1);
 		if(rand.nextInt(14) == 0) dropItem(JourneyItems.boilPowder, 2);
 		super.dropFewItems(b, j);

--- a/main/java/net/journey/entity/mob/boiling/EntityExposedFlame.java
+++ b/main/java/net/journey/entity/mob/boiling/EntityExposedFlame.java
@@ -10,6 +10,7 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.init.SoundEvents;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
+import net.minecraft.util.DamageSource;
 import net.minecraft.util.SoundEvent;
 import net.minecraft.world.World;
 import net.slayer.api.entity.EntityModMob;
@@ -34,17 +35,17 @@ public class EntityExposedFlame extends EntityModMob{
 	}
 
 	@Override
-	public SoundEvent setLivingSound() {
+	public SoundEvent getAmbientSound() {
 		return SoundEvents.ENTITY_BLAZE_AMBIENT;
 	}
 
 	@Override
-	public SoundEvent setHurtSound() {
+	public SoundEvent getHurtSound(DamageSource sourceIn) {
 		return SoundEvents.ENTITY_BLAZE_HURT;
 	}
 
 	@Override
-	public SoundEvent setDeathSound() {
+	public SoundEvent getDeathSound() {
 		return SoundEvents.ENTITY_BLAZE_DEATH;
 	}
 	
@@ -62,7 +63,7 @@ public class EntityExposedFlame extends EntityModMob{
     }
 	
 	@Override
-	public Item getItemDropped() {
+	public Item getDropItem() {
 		return null;
 	}
 	
@@ -73,7 +74,7 @@ public class EntityExposedFlame extends EntityModMob{
 	
 	@Override
 	protected void dropFewItems(boolean b, int j) {
-		Item it = getItemDropped();
+		Item it = getDropItem();
 		this.dropItem(it, 1);
 		if(rand.nextInt(14) == 0) dropItem(JourneyItems.boilPowder, 2);
 		super.dropFewItems(b, j);

--- a/main/java/net/journey/entity/mob/boiling/EntityFrightener.java
+++ b/main/java/net/journey/entity/mob/boiling/EntityFrightener.java
@@ -69,14 +69,14 @@ public class EntityFrightener extends EntityModMob{
 	}
 	
 	@Override
-	public Item getItemDropped() {
+	public Item getDropItem() {
 		return null;
 
 	}
 	
 	@Override
 	protected void dropFewItems(boolean b, int j) {
-		Item it = getItemDropped();
+		Item it = getDropItem();
 		this.dropItem(it, 1);
 		if(rand.nextInt(14) == 0) dropItem(JourneyItems.boilPowder, 2);
 		super.dropFewItems(b, j);
@@ -86,23 +86,5 @@ public class EntityFrightener extends EntityModMob{
 		super.dropFewItems(b, j); 
 		if(rand.nextInt(65) == 0) dropItem(JourneyItems.sizzlingEye, 4);
 		super.dropFewItems(b, j); 
-		}
-
-	@Override
-	public SoundEvent setLivingSound() {
-		// TODO Auto-generated method stub
-		return null;
 	}
-
-	@Override
-	public SoundEvent setHurtSound() {
-		// TODO Auto-generated method stub
-		return null;
-	}
-
-	@Override
-	public SoundEvent setDeathSound() {
-		// TODO Auto-generated method stub
-		return null;
-	}
-	}
+}

--- a/main/java/net/journey/entity/mob/boiling/EntityHellwing.java
+++ b/main/java/net/journey/entity/mob/boiling/EntityHellwing.java
@@ -24,6 +24,7 @@ import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.network.datasync.DataParameter;
 import net.minecraft.network.datasync.DataSerializers;
 import net.minecraft.network.datasync.EntityDataManager;
+import net.minecraft.util.DamageSource;
 import net.minecraft.util.SoundEvent;
 import net.minecraft.util.datafix.DataFixer;
 import net.minecraft.util.math.AxisAlignedBB;
@@ -82,17 +83,17 @@ public class EntityHellwing extends EntityModMob {
     }
     
 	@Override
-	public SoundEvent setLivingSound() {
+	public SoundEvent getAmbientSound() {
 		return JourneySounds.EMPTY;
 	}
 
 	@Override
-	public SoundEvent setHurtSound() {
+	public SoundEvent getHurtSound(DamageSource sourceIn) {
 		return JourneySounds.OVERSEER_HURT;
 	}
 
 	@Override
-	public SoundEvent setDeathSound() {
+	public SoundEvent getDeathSound() {
 		return JourneySounds.OVERSEER_DEATH;
 	}
 	
@@ -189,7 +190,7 @@ public class EntityHellwing extends EntityModMob {
 	}
 
 	@Override
-	public Item getItemDropped() {
+	public Item getDropItem() {
 		return null;
 	}
 	

--- a/main/java/net/journey/entity/mob/boiling/EntityMagmaBlaze.java
+++ b/main/java/net/journey/entity/mob/boiling/EntityMagmaBlaze.java
@@ -175,22 +175,22 @@ public class EntityMagmaBlaze extends EntityModMob {
 	}
 
 	@Override
-	public SoundEvent setLivingSound() {
+	public SoundEvent getAmbientSound() {
 		return SoundEvents.ENTITY_BLAZE_AMBIENT;
 	}
 
 	@Override
-	public SoundEvent setHurtSound() {
+	public SoundEvent getHurtSound(DamageSource sourceIn) {
 		return SoundEvents.ENTITY_BLAZE_HURT;
 	}
 
 	@Override
-	public SoundEvent setDeathSound() {
+	public SoundEvent getDeathSound() {
 		return SoundEvents.ENTITY_BLAZE_DEATH;
 	}
 
 	@Override
-	public Item getItemDropped() {
+	public Item getDropItem() {
 		return Items.BLAZE_ROD;
 	}
 	

--- a/main/java/net/journey/entity/mob/boiling/EntityMagmaGiant.java
+++ b/main/java/net/journey/entity/mob/boiling/EntityMagmaGiant.java
@@ -33,17 +33,17 @@ public class EntityMagmaGiant extends EntityModMob{
 	}
 
 	@Override
-	public SoundEvent setLivingSound() {
+	public SoundEvent getAmbientSound() {
 		return JourneySounds.MAGMA_GIANT;
 	}
 
 	@Override
-	public SoundEvent setHurtSound() {
+	public SoundEvent getHurtSound(DamageSource sourceIn) {
 		return JourneySounds.MAGMA_GIANT_HURT;
 	}
 
 	@Override
-	public SoundEvent setDeathSound() {
+	public SoundEvent getDeathSound() {
 		return JourneySounds.MAGMA_GIANT_HURT;
 	}
 	
@@ -65,7 +65,7 @@ public class EntityMagmaGiant extends EntityModMob{
     }
     
 	@Override
-	public Item getItemDropped() {
+	public Item getDropItem() {
 		return null;
 	}
 	

--- a/main/java/net/journey/entity/mob/boiling/EntityObserver.java
+++ b/main/java/net/journey/entity/mob/boiling/EntityObserver.java
@@ -153,22 +153,22 @@ public class EntityObserver extends EntityModMob {
 	}
 
 	@Override
-	public SoundEvent setLivingSound() {
+	public SoundEvent getAmbientSound() {
 		return SoundEvents.ENTITY_BLAZE_AMBIENT;
 	}
 
 	@Override
-	public SoundEvent setHurtSound() {
+	public SoundEvent getHurtSound(DamageSource sourceIn) {
 		return SoundEvents.ENTITY_BLAZE_HURT;
 	}
 
 	@Override
-	public SoundEvent setDeathSound() {
+	public SoundEvent getDeathSound() {
 		return SoundEvents.ENTITY_BLAZE_DEATH;
 	}
 
 	@Override
-	public Item getItemDropped() {
+	public Item getDropItem() {
 		return Items.BLAZE_ROD;
 	}
 

--- a/main/java/net/journey/entity/mob/boiling/EntityPhoenix.java
+++ b/main/java/net/journey/entity/mob/boiling/EntityPhoenix.java
@@ -4,6 +4,7 @@ import net.journey.JourneyItems;
 import net.journey.JourneySounds;
 import net.journey.entity.MobStats;
 import net.minecraft.item.Item;
+import net.minecraft.util.DamageSource;
 import net.minecraft.util.SoundEvent;
 import net.minecraft.world.World;
 import net.slayer.api.entity.EntityPeacefullUntillAttacked;
@@ -25,22 +26,22 @@ public class EntityPhoenix extends EntityPeacefullUntillAttacked {
 	}
 
 	@Override
-	public SoundEvent setLivingSound() {
+	public SoundEvent getAmbientSound() {
 		return JourneySounds.BIRD;
 	}
 
 	@Override
-	public SoundEvent setHurtSound() {
+	public SoundEvent getHurtSound(DamageSource sourceIn) {
 		return JourneySounds.BIRD_HURT;
 	}
 
 	@Override
-	public SoundEvent setDeathSound() {
+	public SoundEvent getDeathSound() {
 		return JourneySounds.BIRD_DEATH;
 	}
 
 	@Override
-	public Item getItemDropped() {
+	public Item getDropItem() {
 		return JourneyItems.rocMeat;
 	}
 	

--- a/main/java/net/journey/entity/mob/boiling/EntityScreamer.java
+++ b/main/java/net/journey/entity/mob/boiling/EntityScreamer.java
@@ -151,22 +151,22 @@ public class EntityScreamer extends EntityModMob {
 	}
 
 	@Override
-	public SoundEvent setLivingSound() {
+	public SoundEvent getAmbientSound() {
 		return SoundEvents.ENTITY_BLAZE_AMBIENT;
 	}
 
 	@Override
-	public SoundEvent setHurtSound() {
+	public SoundEvent getHurtSound(DamageSource sourceIn) {
 		return SoundEvents.ENTITY_BLAZE_HURT;
 	}
 
 	@Override
-	public SoundEvent setDeathSound() {
+	public SoundEvent getDeathSound() {
 		return SoundEvents.ENTITY_BLAZE_DEATH;
 	}
 
 	@Override
-	public Item getItemDropped() {
+	public Item getDropItem() {
 		return Items.BLAZE_ROD;
 	}
 

--- a/main/java/net/journey/entity/mob/boss/EntityBlazier.java
+++ b/main/java/net/journey/entity/mob/boss/EntityBlazier.java
@@ -202,22 +202,22 @@ public class EntityBlazier extends EntityEssenceBoss implements IRangedAttackMob
 	}
 
 	@Override
-	public SoundEvent setLivingSound() {
+	public SoundEvent getAmbientSound() {
 		return SoundEvents.ENTITY_WITHER_AMBIENT;
 	}
 
 	@Override
-	public SoundEvent setHurtSound() {
+	public SoundEvent getHurtSound(DamageSource sourceIn) {
 		return SoundEvents.ENTITY_WITHER_HURT;
 	}
 
 	@Override
-	public SoundEvent setDeathSound() {
+	public SoundEvent getDeathSound() {
 		return JourneySounds.BOSS_DEATH;
 	}
 
 	@Override
-	public Item getItemDropped() {
+	public Item getDropItem() {
 		return Items.BLAZE_ROD;
 	}
 	

--- a/main/java/net/journey/entity/mob/boss/EntityCalcia.java
+++ b/main/java/net/journey/entity/mob/boss/EntityCalcia.java
@@ -7,6 +7,7 @@ import net.journey.util.PotionEffects;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.Item;
+import net.minecraft.util.DamageSource;
 import net.minecraft.util.EnumParticleTypes;
 import net.minecraft.util.SoundEvent;
 import net.minecraft.world.World;
@@ -40,17 +41,17 @@ public class EntityCalcia extends EntityEssenceBoss {
 	}
 
 	@Override
-	public SoundEvent setLivingSound() {
+	public SoundEvent getAmbientSound() {
 		return JourneySounds.CALCIA;
 	}
 
 	@Override
-	public SoundEvent setHurtSound() {
+	public SoundEvent getHurtSound(DamageSource sourceIn) {
 		return JourneySounds.CALCIA_HURT;
 	}
 
 	@Override
-	public SoundEvent setDeathSound() {
+	public SoundEvent getDeathSound() {
 		return JourneySounds.CALCIA_HURT;
 	}
 
@@ -88,7 +89,7 @@ public class EntityCalcia extends EntityEssenceBoss {
 	}
 
 	@Override
-	public Item getItemDropped() {
+	public Item getDropItem() {
 		return JourneyItems.eucaPortalGem;
 	}
 

--- a/main/java/net/journey/entity/mob/boss/EntityCorallator.java
+++ b/main/java/net/journey/entity/mob/boss/EntityCorallator.java
@@ -63,17 +63,17 @@ public class EntityCorallator extends EntityEssenceBoss implements IRangedAttack
 	}
 
 	@Override
-	public SoundEvent setLivingSound() {
+	public SoundEvent getAmbientSound() {
 		return SoundEvents.ENTITY_WITHER_AMBIENT;
 	}
 
 	@Override
-	public SoundEvent setHurtSound() {
+	public SoundEvent getHurtSound(DamageSource sourceIn) {
 		return SoundEvents.ENTITY_WITHER_HURT;
 	}
 
 	@Override
-	public SoundEvent setDeathSound() {
+	public SoundEvent getDeathSound() {
 		return JourneySounds.BOSS_DEATH;
 	}
 	
@@ -84,7 +84,7 @@ public class EntityCorallator extends EntityEssenceBoss implements IRangedAttack
 	}
 
 	@Override
-	public Item getItemDropped() {
+	public Item getDropItem() {
 		return null;
 	}
 	

--- a/main/java/net/journey/entity/mob/boss/EntityEudor.java
+++ b/main/java/net/journey/entity/mob/boss/EntityEudor.java
@@ -46,17 +46,17 @@ public class EntityEudor extends EntityEssenceBoss {
 	}
 
 	@Override
-	public SoundEvent setLivingSound() {
+	public SoundEvent getAmbientSound() {
 		return JourneySounds.CALCIA;
 	}
 
 	@Override
-	public SoundEvent setHurtSound() {
+	public SoundEvent getHurtSound(DamageSource sourceIn) {
 		return JourneySounds.CALCIA_HURT;
 	}
 
 	@Override
-	public SoundEvent setDeathSound() {
+	public SoundEvent getDeathSound() {
 		return JourneySounds.BOSS_DEATH;
 	}
 
@@ -93,7 +93,7 @@ public class EntityEudor extends EntityEssenceBoss {
 		super.onLivingUpdate();
 	}
 	@Override
-	public Item getItemDropped() {
+	public Item getDropItem() {
 		return null;
 	}
 	

--- a/main/java/net/journey/entity/mob/boss/EntityFourfa.java
+++ b/main/java/net/journey/entity/mob/boss/EntityFourfa.java
@@ -18,6 +18,7 @@ import net.minecraft.init.SoundEvents;
 import net.minecraft.inventory.EntityEquipmentSlot;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
+import net.minecraft.util.DamageSource;
 import net.minecraft.util.EnumHand;
 import net.minecraft.util.SoundEvent;
 import net.minecraft.world.DifficultyInstance;
@@ -129,28 +130,28 @@ public class EntityFourfa extends EntityEssenceBoss implements IRangedAttackMob 
 	}
 
 	@Override
-	public SoundEvent setLivingSound() {
+	public SoundEvent getAmbientSound() {
 		return SoundEvents.ENTITY_WITHER_AMBIENT;
 	}
 
 	@Override
-	public SoundEvent setHurtSound() {
+	public SoundEvent getHurtSound(DamageSource sourceIn) {
 		return SoundEvents.ENTITY_WITHER_HURT;
 	}
 
 	@Override
-	public SoundEvent setDeathSound() {
+	public SoundEvent getDeathSound() {
 		return SoundEvents.ENTITY_WITHER_DEATH;
 	}
 
 	@Override
-	public Item getItemDropped() {
+	public Item getDropItem() {
 		return JourneyItems.depthsPortalGem;
 	}
 
 	@Override
 	protected void dropFewItems(boolean par1, int par2) {
-		this.dropItem(getItemDropped(), 6 + rand.nextInt(4));
+		this.dropItem(getDropItem(), 6 + rand.nextInt(4));
 	//	if(rand.nextInt(1) == 0) this.dropItem(Item.getItemFromBlock(EssenceBlocks.eudorStatue), 1);
 	}
 

--- a/main/java/net/journey/entity/mob/boss/EntityLogger.java
+++ b/main/java/net/journey/entity/mob/boss/EntityLogger.java
@@ -70,17 +70,17 @@ public class EntityLogger extends EntityEssenceBoss {
 	}
 
 	@Override
-	public SoundEvent setLivingSound() {
+	public SoundEvent getAmbientSound() {
 		return JourneySounds.BEAST_OF_THE_NETHER;
 	}
 
 	@Override
-	public SoundEvent setHurtSound() {
+	public SoundEvent getHurtSound(DamageSource sourceIn) {
 		return JourneySounds.BEAST_OF_THE_NETHER_HURT;
 	}
 
 	@Override
-	public SoundEvent setDeathSound() {
+	public SoundEvent getDeathSound() {
 		return JourneySounds.BOSS_DEATH;
 	}
 
@@ -124,7 +124,7 @@ public class EntityLogger extends EntityEssenceBoss {
 	}
 
 	@Override
-	public Item getItemDropped() {
+	public Item getDropItem() {
 		return null;
 	}
 }

--- a/main/java/net/journey/entity/mob/boss/EntityNetherBeast.java
+++ b/main/java/net/journey/entity/mob/boss/EntityNetherBeast.java
@@ -69,22 +69,22 @@ public class EntityNetherBeast extends EntityEssenceBoss {
 	}
 
 	@Override
-	public SoundEvent setLivingSound() {
+	public SoundEvent getAmbientSound() {
 		return JourneySounds.BEAST_OF_THE_NETHER;
 	}
 
 	@Override
-	public SoundEvent setHurtSound() {
+	public SoundEvent getHurtSound(DamageSource sourceIn) {
 		return JourneySounds.BEAST_OF_THE_NETHER_HURT;
 	}
 
 	@Override
-	public SoundEvent setDeathSound() {
+	public SoundEvent getDeathSound() {
 		return JourneySounds.BOSS_DEATH;
 	}
 	
 	@Override
-	public Item getItemDropped() {
+	public Item getDropItem() {
 		return null;
 	}
 	

--- a/main/java/net/journey/entity/mob/boss/EntityScale.java
+++ b/main/java/net/journey/entity/mob/boss/EntityScale.java
@@ -61,17 +61,17 @@ public class EntityScale extends EntityEssenceBoss implements IRangedAttackMob {
 	}
 
 	@Override
-	public SoundEvent setLivingSound() {
+	public SoundEvent getAmbientSound() {
 		return SoundEvents.ENTITY_WITHER_AMBIENT;
 	}
 
 	@Override
-	public SoundEvent setHurtSound() {
+	public SoundEvent getHurtSound(DamageSource sourceIn) {
 		return SoundEvents.ENTITY_WITHER_HURT;
 	}
 
 	@Override
-	public SoundEvent setDeathSound() {
+	public SoundEvent getDeathSound() {
 		return JourneySounds.BOSS_DEATH;
 	}
 	
@@ -278,7 +278,7 @@ public class EntityScale extends EntityEssenceBoss implements IRangedAttackMob {
 	}
 
 	@Override
-	public Item getItemDropped() {
+	public Item getDropItem() {
 		return null;
 	}
 	

--- a/main/java/net/journey/entity/mob/boss/EntitySentryKing.java
+++ b/main/java/net/journey/entity/mob/boss/EntitySentryKing.java
@@ -110,17 +110,17 @@ public class EntitySentryKing extends EntityEssenceBoss implements IRangedAttack
 	}
 
 	@Override
-	public SoundEvent setLivingSound() {
+	public SoundEvent getAmbientSound() {
 		return SoundEvents.ENTITY_WITHER_AMBIENT;
 	}
 
 	@Override
-	public SoundEvent setHurtSound() {
+	public SoundEvent getHurtSound(DamageSource sourceIn) {
 		return SoundEvents.ENTITY_WITHER_HURT;
 	}
 
 	@Override
-	public SoundEvent setDeathSound() {
+	public SoundEvent getDeathSound() {
 		return JourneySounds.BOSS_DEATH;
 	}
 	
@@ -131,7 +131,7 @@ public class EntitySentryKing extends EntityEssenceBoss implements IRangedAttack
 	}
 
 	@Override
-	public Item getItemDropped() {
+	public Item getDropItem() {
 		return null;
 	}
 	

--- a/main/java/net/journey/entity/mob/boss/EntitySkyStalker.java
+++ b/main/java/net/journey/entity/mob/boss/EntitySkyStalker.java
@@ -108,17 +108,17 @@ public class EntitySkyStalker extends EntityEssenceBoss implements IRangedAttack
 	}
 
 	@Override
-	public SoundEvent setLivingSound() {
+	public SoundEvent getAmbientSound() {
 		return SoundEvents.ENTITY_WITHER_AMBIENT;
 	}
 
 	@Override
-	public SoundEvent setHurtSound() {
+	public SoundEvent getHurtSound(DamageSource sourceIn) {
 		return SoundEvents.ENTITY_WITHER_HURT;
 	}
 
 	@Override
-	public SoundEvent setDeathSound() {
+	public SoundEvent getDeathSound() {
 		return JourneySounds.BOSS_DEATH;
 	}
 	
@@ -129,7 +129,7 @@ public class EntitySkyStalker extends EntityEssenceBoss implements IRangedAttack
 	}
 
 	@Override
-	public Item getItemDropped() {
+	public Item getDropItem() {
 		return null;
 	}
 

--- a/main/java/net/journey/entity/mob/boss/EntitySoulWatcher.java
+++ b/main/java/net/journey/entity/mob/boss/EntitySoulWatcher.java
@@ -64,17 +64,17 @@ public class EntitySoulWatcher extends EntityEssenceBoss implements IRangedAttac
 	}
 
 	@Override
-	public SoundEvent setLivingSound() {
+	public SoundEvent getAmbientSound() {
 		return SoundEvents.ENTITY_WITHER_AMBIENT;
 	}
 
 	@Override
-	public SoundEvent setHurtSound() {
+	public SoundEvent getHurtSound(DamageSource sourceIn) {
 		return SoundEvents.ENTITY_WITHER_HURT;
 	}
 
 	@Override
-	public SoundEvent setDeathSound() {
+	public SoundEvent getDeathSound() {
 		return JourneySounds.BOSS_DEATH;
 	}
 	
@@ -85,7 +85,7 @@ public class EntitySoulWatcher extends EntityEssenceBoss implements IRangedAttac
 	}
 
 	@Override
-	public Item getItemDropped() {
+	public Item getDropItem() {
 		return null;
 	}
 	

--- a/main/java/net/journey/entity/mob/boss/EntityTempleGuardian.java
+++ b/main/java/net/journey/entity/mob/boss/EntityTempleGuardian.java
@@ -172,17 +172,17 @@ public class EntityTempleGuardian extends EntityEssenceBoss implements IRangedAt
 	}
 	
 	@Override
-	public SoundEvent setDeathSound() {
+	public SoundEvent getDeathSound() {
 		return JourneySounds.BOSS_DEATH;
 	}
 	
 	@Override
-	public SoundEvent setLivingSound() {
+	public SoundEvent getAmbientSound() {
 		return SoundEvents.ENTITY_BLAZE_AMBIENT;
 	}
 
 	@Override
-	public Item getItemDropped() {
+	public Item getDropItem() {
 		return null;
 	}
 
@@ -192,7 +192,7 @@ public class EntityTempleGuardian extends EntityEssenceBoss implements IRangedAt
 	}
 
 	@Override
-	public SoundEvent setHurtSound() {
+	public SoundEvent getHurtSound(DamageSource sourceIn) {
 		return SoundEvents.ENTITY_BLAZE_HURT;
 	}
     

--- a/main/java/net/journey/entity/mob/boss/EntityTerranianProtector.java
+++ b/main/java/net/journey/entity/mob/boss/EntityTerranianProtector.java
@@ -111,17 +111,17 @@ public class EntityTerranianProtector extends EntityEssenceBoss implements IRang
 	}
 
 	@Override
-	public SoundEvent setLivingSound() {
+	public SoundEvent getAmbientSound() {
 		return SoundEvents.ENTITY_WITHER_AMBIENT;
 	}
 
 	@Override
-	public SoundEvent setHurtSound() {
+	public SoundEvent getHurtSound(DamageSource sourceIn) {
 		return SoundEvents.ENTITY_WITHER_HURT;
 	}
 
 	@Override
-	public SoundEvent setDeathSound() {
+	public SoundEvent getDeathSound() {
 		return JourneySounds.BOSS_DEATH;
 	}
 	
@@ -132,7 +132,7 @@ public class EntityTerranianProtector extends EntityEssenceBoss implements IRang
 	}
 
 	@Override
-	public Item getItemDropped() {
+	public Item getDropItem() {
 		return null;
 	}
 	

--- a/main/java/net/journey/entity/mob/boss/EntityThunderbird.java
+++ b/main/java/net/journey/entity/mob/boss/EntityThunderbird.java
@@ -70,22 +70,22 @@ public class EntityThunderbird extends EntityEssenceBoss {
 	}
 
 	@Override
-	public SoundEvent setLivingSound() {
+	public SoundEvent getAmbientSound() {
 		return JourneySounds.BEAST_OF_THE_NETHER;
 	}
 
 	@Override
-	public SoundEvent setHurtSound() {
+	public SoundEvent getHurtSound(DamageSource sourceIn) {
 		return JourneySounds.BEAST_OF_THE_NETHER_HURT;
 	}
 
 	@Override
-	public SoundEvent setDeathSound() {
+	public SoundEvent getDeathSound() {
 		return JourneySounds.BOSS_DEATH;
 	}
 
 	@Override
-	public Item getItemDropped() {
+	public Item getDropItem() {
 		return JourneyItems.corbaPortalGem;
 	}
 

--- a/main/java/net/journey/entity/mob/boss/EntityWitheringBeast.java
+++ b/main/java/net/journey/entity/mob/boss/EntityWitheringBeast.java
@@ -64,22 +64,22 @@ public class EntityWitheringBeast extends EntityEssenceBoss implements IRangedAt
 	}
 
 	@Override
-	public SoundEvent setLivingSound() {
+	public SoundEvent getAmbientSound() {
 		return SoundEvents.ENTITY_WITHER_AMBIENT;
 	}
 
 	@Override
-	public SoundEvent setHurtSound() {
+	public SoundEvent getHurtSound(DamageSource sourceIn) {
 		return SoundEvents.ENTITY_WITHER_HURT;
 	}
 
 	@Override
-	public SoundEvent setDeathSound() {
+	public SoundEvent getDeathSound() {
 		return JourneySounds.BOSS_DEATH;
 	}
 
 	@Override
-	public Item getItemDropped() {
+	public Item getDropItem() {
 		return null;
 	}
 

--- a/main/java/net/journey/entity/mob/boss/EntityWraith.java
+++ b/main/java/net/journey/entity/mob/boss/EntityWraith.java
@@ -2,6 +2,7 @@ package net.journey.entity.mob.boss;
 
 import net.journey.entity.MobStats;
 import net.minecraft.item.Item;
+import net.minecraft.util.DamageSource;
 import net.minecraft.util.SoundEvent;
 import net.minecraft.world.World;
 import net.slayer.api.entity.EntityEssenceBoss;
@@ -24,22 +25,22 @@ public class EntityWraith extends EntityEssenceBoss {
 	}
 
 	@Override
-	public SoundEvent setLivingSound() {
+	public SoundEvent getAmbientSound() {
 		return null;
 	}
 
 	@Override
-	public SoundEvent setHurtSound() {
+	public SoundEvent getHurtSound(DamageSource sourceIn) {
 		return null;
 	}
 
 	@Override
-	public SoundEvent setDeathSound() {
+	public SoundEvent getDeathSound() {
 		return null;
 	}
 
 	@Override
-	public Item getItemDropped() {
+	public Item getDropItem() {
 		return null;
 	}
 }

--- a/main/java/net/journey/entity/mob/cloudia/EntityCloudFlyer.java
+++ b/main/java/net/journey/entity/mob/cloudia/EntityCloudFlyer.java
@@ -4,6 +4,7 @@ import net.journey.JourneyItems;
 import net.journey.JourneySounds;
 import net.journey.entity.MobStats;
 import net.minecraft.item.Item;
+import net.minecraft.util.DamageSource;
 import net.minecraft.util.SoundEvent;
 import net.minecraft.world.World;
 import net.slayer.api.entity.EntityPeacefullUntillAttacked;
@@ -26,22 +27,22 @@ public class EntityCloudFlyer extends EntityPeacefullUntillAttacked {
 	}
 
 	@Override
-	public SoundEvent setLivingSound() {
+	public SoundEvent getAmbientSound() {
 		return JourneySounds.BIRD;
 	}
 
 	@Override
-	public SoundEvent setHurtSound() {
+	public SoundEvent getHurtSound(DamageSource sourceIn) {
 		return JourneySounds.BIRD_HURT;
 	}
 
 	@Override
-	public SoundEvent setDeathSound() {
+	public SoundEvent getDeathSound() {
 		return JourneySounds.BIRD_DEATH;
 	}
 
 	@Override
-	public Item getItemDropped() {
+	public Item getDropItem() {
 		return JourneyItems.rocMeat;
 	}
 	

--- a/main/java/net/journey/entity/mob/cloudia/EntityCloudGhost.java
+++ b/main/java/net/journey/entity/mob/cloudia/EntityCloudGhost.java
@@ -3,6 +3,7 @@ package net.journey.entity.mob.cloudia;
 import net.journey.JourneySounds;
 import net.journey.entity.MobStats;
 import net.minecraft.item.Item;
+import net.minecraft.util.DamageSource;
 import net.minecraft.util.SoundEvent;
 import net.minecraft.world.World;
 import net.slayer.api.entity.EntityModMob;
@@ -26,22 +27,22 @@ public class EntityCloudGhost extends EntityModMob{
 	}
 
 	@Override
-	public SoundEvent setLivingSound() {
+	public SoundEvent getAmbientSound() {
 		return JourneySounds.SPIKED_BEAST;
 	}
 
 	@Override
-	public SoundEvent setHurtSound() {
+	public SoundEvent getHurtSound(DamageSource sourceIn) {
 		return JourneySounds.SPIKED_BEAST_HURT;
 	}
 
 	@Override
-	public SoundEvent setDeathSound() {
+	public SoundEvent getDeathSound() {
 		return JourneySounds.SPIKED_BEAST_HURT;
 	}
 	
 	@Override
-	public Item getItemDropped() {
+	public Item getDropItem() {
 		return null;
 	}
 }

--- a/main/java/net/journey/entity/mob/cloudia/EntitySkyEel.java
+++ b/main/java/net/journey/entity/mob/cloudia/EntitySkyEel.java
@@ -71,7 +71,7 @@ public class EntitySkyEel extends EntityModFlying {
 	}		
 
 	@Override
-	public Item getItemDropped() {
+	public Item getDropItem() {
 		return null;
 	}
 
@@ -395,24 +395,6 @@ public class EntitySkyEel extends EntityModFlying {
                 return true;
             }
         }
-
-	@Override
-	public SoundEvent setLivingSound() {
-		// TODO Auto-generated method stub
-		return null;
-	}
-
-	@Override
-	public SoundEvent setHurtSound() {
-		// TODO Auto-generated method stub
-		return null;
-	}
-
-	@Override
-	public SoundEvent setDeathSound() {
-		// TODO Auto-generated method stub
-		return null;
-	}
 
 	@Override
 	public double setMaxHealth(MobStats s) {

--- a/main/java/net/journey/entity/mob/cloudia/EntityStarlightGolem.java
+++ b/main/java/net/journey/entity/mob/cloudia/EntityStarlightGolem.java
@@ -6,6 +6,7 @@ import net.journey.entity.MobStats;
 import net.minecraft.block.Block;
 import net.minecraft.init.SoundEvents;
 import net.minecraft.item.Item;
+import net.minecraft.util.DamageSource;
 import net.minecraft.util.SoundEvent;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
@@ -30,17 +31,17 @@ public class EntityStarlightGolem extends EntityModMob {
 	}
 
 	@Override
-	public SoundEvent setLivingSound() {
+	public SoundEvent getAmbientSound() {
 		return JourneySounds.EMPTY;
 	}
 
 	@Override
-	public SoundEvent setHurtSound() {
+	public SoundEvent getHurtSound(DamageSource sourceIn) {
 		return SoundEvents.ENTITY_IRONGOLEM_HURT;
 	}
 
 	@Override
-	public SoundEvent setDeathSound() {
+	public SoundEvent getDeathSound() {
 		return SoundEvents.ENTITY_IRONGOLEM_DEATH;
 	}
 	
@@ -60,7 +61,7 @@ public class EntityStarlightGolem extends EntityModMob {
 	}
 
 	@Override
-	public Item getItemDropped() {
+	public Item getDropItem() {
 		return null;
 	}
 

--- a/main/java/net/journey/entity/mob/cloudia/EntityStarlightTransporter.java
+++ b/main/java/net/journey/entity/mob/cloudia/EntityStarlightTransporter.java
@@ -4,6 +4,7 @@ import net.journey.JourneyItems;
 import net.journey.JourneySounds;
 import net.journey.entity.MobStats;
 import net.minecraft.item.Item;
+import net.minecraft.util.DamageSource;
 import net.minecraft.util.SoundEvent;
 import net.minecraft.world.World;
 import net.slayer.api.entity.EntityPeacefullUntillAttacked;
@@ -26,17 +27,17 @@ public class EntityStarlightTransporter extends EntityPeacefullUntillAttacked {
 	}
 
 	@Override
-	public SoundEvent setLivingSound() {
+	public SoundEvent getAmbientSound() {
 		return JourneySounds.BUSH;
 	}
 
 	@Override
-	public SoundEvent setHurtSound() {
+	public SoundEvent getHurtSound(DamageSource sourceIn) {
 		return JourneySounds.BUSH_HURT;
 	}
 
 	@Override
-	public SoundEvent setDeathSound() {
+	public SoundEvent getDeathSound() {
 		return JourneySounds.BUSH_DEATH;
 	}
 	
@@ -48,7 +49,7 @@ public class EntityStarlightTransporter extends EntityPeacefullUntillAttacked {
 	}
 
 	@Override
-	public Item getItemDropped() {
+	public Item getDropItem() {
 		return JourneyItems.cloudiaOrb;
 	}
 

--- a/main/java/net/journey/entity/mob/cloudia/EntityStarlightWalker.java
+++ b/main/java/net/journey/entity/mob/cloudia/EntityStarlightWalker.java
@@ -5,6 +5,7 @@ import net.journey.JourneySounds;
 import net.journey.entity.MobStats;
 import net.minecraft.init.SoundEvents;
 import net.minecraft.item.Item;
+import net.minecraft.util.DamageSource;
 import net.minecraft.util.SoundEvent;
 import net.minecraft.world.World;
 import net.slayer.api.entity.EntityModMob;
@@ -27,17 +28,17 @@ public class EntityStarlightWalker extends EntityModMob {
 	}
 
 	@Override
-	public SoundEvent setLivingSound() {
+	public SoundEvent getAmbientSound() {
 		return JourneySounds.EMPTY;
 	}
 
 	@Override
-	public SoundEvent setHurtSound() {
+	public SoundEvent getHurtSound(DamageSource sourceIn) {
 		return SoundEvents.ENTITY_IRONGOLEM_HURT;
 	}
 
 	@Override
-	public SoundEvent setDeathSound() {
+	public SoundEvent getDeathSound() {
 		return SoundEvents.ENTITY_IRONGOLEM_DEATH;
 	}
 	
@@ -49,7 +50,7 @@ public class EntityStarlightWalker extends EntityModMob {
 	}
 
 	@Override
-	public Item getItemDropped() {
+	public Item getDropItem() {
 		return null;
 	}
 

--- a/main/java/net/journey/entity/mob/corba/EntityLeafBlower.java
+++ b/main/java/net/journey/entity/mob/corba/EntityLeafBlower.java
@@ -9,6 +9,7 @@ import net.journey.util.PotionEffects;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.Item;
+import net.minecraft.util.DamageSource;
 import net.minecraft.util.SoundEvent;
 import net.minecraft.world.World;
 import net.slayer.api.entity.EntityModMob;
@@ -32,22 +33,22 @@ public class EntityLeafBlower extends EntityModMob{
 	}
 
 	@Override
-	public SoundEvent setLivingSound() {
+	public SoundEvent getAmbientSound() {
 		return JourneySounds.BUSH;
 	}
 
 	@Override
-	public SoundEvent setHurtSound() {
+	public SoundEvent getHurtSound(DamageSource sourceIn) {
 		return JourneySounds.BUSH_HURT;
 	}
 
 	@Override
-	public SoundEvent setDeathSound() {
+	public SoundEvent getDeathSound() {
 		return JourneySounds.BUSH_DEATH;
 	}
 	
 	@Override
-	public Item getItemDropped() {
+	public Item getDropItem() {
 		return null; 
 	
 	}
@@ -67,7 +68,7 @@ public class EntityLeafBlower extends EntityModMob{
 		
 	@Override
 	protected void dropFewItems(boolean b, int j) {
-		Item it = getItemDropped();
+		Item it = getDropItem();
 		this.dropItem(it, 1);
 		if(rand.nextInt(6) == 0) dropItem(JourneyItems.corbaStick, 2);
 		if(rand.nextInt(12) == 0) dropItem(JourneyItems.corbaStick, 4);

--- a/main/java/net/journey/entity/mob/corba/EntityNatureMage.java
+++ b/main/java/net/journey/entity/mob/corba/EntityNatureMage.java
@@ -17,6 +17,7 @@ import net.minecraft.inventory.EntityEquipmentSlot;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.util.DamageSource;
 import net.minecraft.util.EnumHand;
 import net.minecraft.util.SoundEvent;
 import net.minecraft.util.math.BlockPos;
@@ -119,22 +120,22 @@ public class EntityNatureMage extends EntityModMob implements IRangedAttackMob {
 	}
 
 	@Override
-	public SoundEvent setLivingSound() {
+	public SoundEvent getAmbientSound() {
 		return JourneySounds.INSECTO;
 	}
 
 	@Override
-	public SoundEvent setHurtSound() {
+	public SoundEvent getHurtSound(DamageSource sourceIn) {
 		return JourneySounds.INSECTO_HURT;
 	}
 
 	@Override
-	public SoundEvent setDeathSound() {
+	public SoundEvent getDeathSound() {
 		return JourneySounds.INSECTO_HURT;
 	}
 
 	@Override
-	public Item getItemDropped() {
+	public Item getDropItem() {
 		return null;
 	}
 	

--- a/main/java/net/journey/entity/mob/corba/EntityOverseer.java
+++ b/main/java/net/journey/entity/mob/corba/EntityOverseer.java
@@ -68,7 +68,7 @@ public class EntityOverseer extends EntityModFlying {
 	}		
 
 	@Override
-	public Item getItemDropped() {
+	public Item getDropItem() {
 		return null;
 	}
 
@@ -392,24 +392,6 @@ public class EntityOverseer extends EntityModFlying {
                 return true;
             }
         }
-
-	@Override
-	public SoundEvent setLivingSound() {
-		// TODO Auto-generated method stub
-		return null;
-	}
-
-	@Override
-	public SoundEvent setHurtSound() {
-		// TODO Auto-generated method stub
-		return null;
-	}
-
-	@Override
-	public SoundEvent setDeathSound() {
-		// TODO Auto-generated method stub
-		return null;
-	}
 
 	@Override
 	public double setMaxHealth(MobStats s) {

--- a/main/java/net/journey/entity/mob/corba/EntityOverseerElder.java
+++ b/main/java/net/journey/entity/mob/corba/EntityOverseerElder.java
@@ -71,7 +71,7 @@ public class EntityOverseerElder extends EntityModFlying {
 	}		
 
 	@Override
-	public Item getItemDropped() {
+	public Item getDropItem() {
 		return null;
 	}
 
@@ -395,24 +395,6 @@ public class EntityOverseerElder extends EntityModFlying {
                 return true;
             }
         }
-
-	@Override
-	public SoundEvent setLivingSound() {
-		// TODO Auto-generated method stub
-		return null;
-	}
-
-	@Override
-	public SoundEvent setHurtSound() {
-		// TODO Auto-generated method stub
-		return null;
-	}
-
-	@Override
-	public SoundEvent setDeathSound() {
-		// TODO Auto-generated method stub
-		return null;
-	}
 
 	@Override
 	public double setMaxHealth(MobStats s) {

--- a/main/java/net/journey/entity/mob/corba/EntitySurfaceSeer.java
+++ b/main/java/net/journey/entity/mob/corba/EntitySurfaceSeer.java
@@ -69,7 +69,7 @@ public class EntitySurfaceSeer extends EntityModFlying {
 	}		
 
 	@Override
-	public Item getItemDropped() {
+	public Item getDropItem() {
 		return null;
 	}
 
@@ -393,24 +393,6 @@ public class EntitySurfaceSeer extends EntityModFlying {
                 return true;
             }
         }
-
-	@Override
-	public SoundEvent setLivingSound() {
-		// TODO Auto-generated method stub
-		return null;
-	}
-
-	@Override
-	public SoundEvent setHurtSound() {
-		// TODO Auto-generated method stub
-		return null;
-	}
-
-	@Override
-	public SoundEvent setDeathSound() {
-		// TODO Auto-generated method stub
-		return null;
-	}
 
 	@Override
 	public double setMaxHealth(MobStats s) {

--- a/main/java/net/journey/entity/mob/corba/EntityTreeGolem.java
+++ b/main/java/net/journey/entity/mob/corba/EntityTreeGolem.java
@@ -11,6 +11,7 @@ import net.minecraft.entity.Entity;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.init.SoundEvents;
 import net.minecraft.item.Item;
+import net.minecraft.util.DamageSource;
 import net.minecraft.util.SoundEvent;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.MathHelper;
@@ -58,7 +59,7 @@ public class EntityTreeGolem extends EntityModMob{
 	}
 
 	@Override
-	public SoundEvent setLivingSound() {
+	public SoundEvent getAmbientSound() {
 		return JourneySounds.BUSH;
 	}
 
@@ -68,17 +69,17 @@ public class EntityTreeGolem extends EntityModMob{
     }
 	
 	@Override
-	public SoundEvent setHurtSound() {
+	public SoundEvent getHurtSound(DamageSource sourceIn) {
 		return JourneySounds.BUSH_HURT;
 	}
 
 	@Override
-	public SoundEvent setDeathSound() {
+	public SoundEvent getDeathSound() {
 		return JourneySounds.BUSH_DEATH;
 	}
 	
 	@Override
-	public Item getItemDropped() {
+	public Item getDropItem() {
 		return null;
 	}
 	

--- a/main/java/net/journey/entity/mob/corba/EntityWoodCreature.java
+++ b/main/java/net/journey/entity/mob/corba/EntityWoodCreature.java
@@ -9,6 +9,7 @@ import net.journey.util.PotionEffects;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.Item;
+import net.minecraft.util.DamageSource;
 import net.minecraft.util.SoundEvent;
 import net.minecraft.world.World;
 import net.slayer.api.entity.EntityModMob;
@@ -32,17 +33,17 @@ public class EntityWoodCreature extends EntityModMob{
 	}
 
 	@Override
-	public SoundEvent setLivingSound() {
+	public SoundEvent getAmbientSound() {
 		return JourneySounds.BUSH;
 	}
 
 	@Override
-	public SoundEvent setHurtSound() {
+	public SoundEvent getHurtSound(DamageSource sourceIn) {
 		return JourneySounds.BUSH_HURT;
 	}
 
 	@Override
-	public SoundEvent setDeathSound() {
+	public SoundEvent getDeathSound() {
 		return JourneySounds.BUSH_DEATH;
 	}
 	
@@ -60,7 +61,7 @@ public class EntityWoodCreature extends EntityModMob{
     }
 	
 	@Override
-	public Item getItemDropped() {
+	public Item getDropItem() {
 		return null;
 	}
 	

--- a/main/java/net/journey/entity/mob/corba/EntityWoodpecker.java
+++ b/main/java/net/journey/entity/mob/corba/EntityWoodpecker.java
@@ -4,6 +4,7 @@ import net.journey.JourneyItems;
 import net.journey.JourneySounds;
 import net.journey.entity.MobStats;
 import net.minecraft.item.Item;
+import net.minecraft.util.DamageSource;
 import net.minecraft.util.SoundEvent;
 import net.minecraft.world.World;
 import net.slayer.api.entity.EntityPeacefullUntillAttacked;
@@ -25,22 +26,22 @@ public class EntityWoodpecker extends EntityPeacefullUntillAttacked {
 	}
 	
 	@Override
-	public SoundEvent setLivingSound() {
+	public SoundEvent getAmbientSound() {
 		return JourneySounds.BIRD;
 	}
 
 	@Override
-	public SoundEvent setHurtSound() {
+	public SoundEvent getHurtSound(DamageSource sourceIn) {
 		return JourneySounds.BIRD_HURT;
 	}
 
 	@Override
-	public SoundEvent setDeathSound() {
+	public SoundEvent getDeathSound() {
 		return JourneySounds.BIRD_DEATH;
 	}
 
 	@Override
-	public Item getItemDropped() {
+	public Item getDropItem() {
 		return JourneyItems.rocMeat;
 	}
 	

--- a/main/java/net/journey/entity/mob/depths/EntityDarkSorcerer.java
+++ b/main/java/net/journey/entity/mob/depths/EntityDarkSorcerer.java
@@ -17,6 +17,7 @@ import net.minecraft.inventory.EntityEquipmentSlot;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.util.DamageSource;
 import net.minecraft.util.EnumHand;
 import net.minecraft.util.SoundEvent;
 import net.minecraft.util.math.BlockPos;
@@ -119,22 +120,22 @@ public class EntityDarkSorcerer extends EntityModMob implements IRangedAttackMob
 	}
 
 	@Override
-	public SoundEvent setLivingSound() {
+	public SoundEvent getAmbientSound() {
 		return JourneySounds.INSECTO;
 	}
 
 	@Override
-	public SoundEvent setHurtSound() {
+	public SoundEvent getHurtSound(DamageSource sourceIn) {
 		return JourneySounds.INSECTO_HURT;
 	}
 
 	@Override
-	public SoundEvent setDeathSound() {
+	public SoundEvent getDeathSound() {
 		return JourneySounds.INSECTO_HURT;
 	}
 
 	@Override
-	public Item getItemDropped() {
+	public Item getDropItem() {
 		return null;
 	}
 	

--- a/main/java/net/journey/entity/mob/depths/EntityDarkener.java
+++ b/main/java/net/journey/entity/mob/depths/EntityDarkener.java
@@ -74,7 +74,7 @@ public class EntityDarkener extends EntityModFlying {
 	}		
 
 	@Override
-	public Item getItemDropped() {
+	public Item getDropItem() {
 		return null;
 	}
 
@@ -398,24 +398,6 @@ public class EntityDarkener extends EntityModFlying {
                 return true;
             }
         }
-
-	@Override
-	public SoundEvent setLivingSound() {
-		// TODO Auto-generated method stub
-		return null;
-	}
-
-	@Override
-	public SoundEvent setHurtSound() {
-		// TODO Auto-generated method stub
-		return null;
-	}
-
-	@Override
-	public SoundEvent setDeathSound() {
-		// TODO Auto-generated method stub
-		return null;
-	}
 
 	@Override
 	public double setMaxHealth(MobStats s) {

--- a/main/java/net/journey/entity/mob/depths/EntityDarkfish.java
+++ b/main/java/net/journey/entity/mob/depths/EntityDarkfish.java
@@ -67,7 +67,7 @@ public class EntityDarkfish extends EntityModFlying {
 	}		
 
 	@Override
-	public Item getItemDropped() {
+	public Item getDropItem() {
 		return null;
 	}
 
@@ -391,24 +391,6 @@ public class EntityDarkfish extends EntityModFlying {
                 return true;
             }
         }
-
-	@Override
-	public SoundEvent setLivingSound() {
-		// TODO Auto-generated method stub
-		return null;
-	}
-
-	@Override
-	public SoundEvent setHurtSound() {
-		// TODO Auto-generated method stub
-		return null;
-	}
-
-	@Override
-	public SoundEvent setDeathSound() {
-		// TODO Auto-generated method stub
-		return null;
-	}
 
 	@Override
 	public double setMaxHealth(MobStats s) {

--- a/main/java/net/journey/entity/mob/depths/EntityDarknessCrawler.java
+++ b/main/java/net/journey/entity/mob/depths/EntityDarknessCrawler.java
@@ -8,6 +8,7 @@ import net.journey.util.PotionEffects;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.Item;
+import net.minecraft.util.DamageSource;
 import net.minecraft.util.SoundEvent;
 import net.minecraft.world.World;
 import net.slayer.api.entity.EntityModMob;
@@ -44,22 +45,22 @@ public class EntityDarknessCrawler extends EntityModMob{
 	}
 
 	@Override
-	public SoundEvent setLivingSound() {
+	public SoundEvent getAmbientSound() {
 		return JourneySounds.SPIKED_BEAST;
 	}
 
 	@Override
-	public SoundEvent setHurtSound() {
+	public SoundEvent getHurtSound(DamageSource sourceIn) {
 		return JourneySounds.SPIKED_BEAST_HURT;
 	}
 
 	@Override
-	public SoundEvent setDeathSound() {
+	public SoundEvent getDeathSound() {
 		return JourneySounds.SPIKED_BEAST_HURT;
 	}
 	
 	@Override
-	public Item getItemDropped() {
+	public Item getDropItem() {
 		return null;
 	}
 }

--- a/main/java/net/journey/entity/mob/depths/EntityDepthsBeast.java
+++ b/main/java/net/journey/entity/mob/depths/EntityDepthsBeast.java
@@ -9,6 +9,7 @@ import net.journey.util.PotionEffects;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.Item;
+import net.minecraft.util.DamageSource;
 import net.minecraft.util.SoundEvent;
 import net.minecraft.world.World;
 import net.slayer.api.entity.EntityModMob;
@@ -45,22 +46,22 @@ public class EntityDepthsBeast extends EntityModMob{
 	}
 
 	@Override
-	public SoundEvent setLivingSound() {
+	public SoundEvent getAmbientSound() {
 		return JourneySounds.MAGMA_GIANT;
 	}
 
 	@Override
-	public SoundEvent setHurtSound() {
+	public SoundEvent getHurtSound(DamageSource sourceIn) {
 		return JourneySounds.SPYCLOPS_HURT;
 	}
 
 	@Override
-	public SoundEvent setDeathSound() {
+	public SoundEvent getDeathSound() {
 		return JourneySounds.SPYCLOPS_HURT;
 	}
 	
 	@Override
-	public Item getItemDropped() {
+	public Item getDropItem() {
 		return null;
 		
 	}

--- a/main/java/net/journey/entity/mob/depths/EntityDepthsHunter.java
+++ b/main/java/net/journey/entity/mob/depths/EntityDepthsHunter.java
@@ -8,6 +8,7 @@ import net.journey.util.PotionEffects;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.Item;
+import net.minecraft.util.DamageSource;
 import net.minecraft.util.SoundEvent;
 import net.minecraft.world.World;
 import net.slayer.api.entity.EntityModMob;
@@ -44,22 +45,22 @@ public class EntityDepthsHunter extends EntityModMob{
 	}
 
 	@Override
-	public SoundEvent setLivingSound() {
+	public SoundEvent getAmbientSound() {
 		return JourneySounds.DEPTHS_HUNTER;
 	}
 
 	@Override
-	public SoundEvent setHurtSound() {
+	public SoundEvent getHurtSound(DamageSource sourceIn) {
 		return JourneySounds.DEPTHS_HUNTER_HURT;
 	}
 
 	@Override
-	public SoundEvent setDeathSound() {
+	public SoundEvent getDeathSound() {
 		return JourneySounds.DEPTHS_HUNTER_HURT;
 	}
 	
 	@Override
-	public Item getItemDropped() {
+	public Item getDropItem() {
 		return null;
 	}
 }

--- a/main/java/net/journey/entity/mob/depths/EntityLightener.java
+++ b/main/java/net/journey/entity/mob/depths/EntityLightener.java
@@ -74,7 +74,7 @@ public class EntityLightener extends EntityModFlying {
 	}		
 
 	@Override
-	public Item getItemDropped() {
+	public Item getDropItem() {
 		return null;
 	}
 
@@ -398,24 +398,6 @@ public class EntityLightener extends EntityModFlying {
                 return true;
             }
         }
-
-	@Override
-	public SoundEvent setLivingSound() {
-		// TODO Auto-generated method stub
-		return null;
-	}
-
-	@Override
-	public SoundEvent setHurtSound() {
-		// TODO Auto-generated method stub
-		return null;
-	}
-
-	@Override
-	public SoundEvent setDeathSound() {
-		// TODO Auto-generated method stub
-		return null;
-	}
 
 	@Override
 	public double setMaxHealth(MobStats s) {

--- a/main/java/net/journey/entity/mob/depths/EntityRoc.java
+++ b/main/java/net/journey/entity/mob/depths/EntityRoc.java
@@ -4,6 +4,7 @@ import net.journey.JourneyItems;
 import net.journey.JourneySounds;
 import net.journey.entity.MobStats;
 import net.minecraft.item.Item;
+import net.minecraft.util.DamageSource;
 import net.minecraft.util.SoundEvent;
 import net.minecraft.world.World;
 import net.slayer.api.entity.EntityPeacefullUntillAttacked;
@@ -25,22 +26,22 @@ public class EntityRoc extends EntityPeacefullUntillAttacked {
 	}
 
 	@Override
-	public SoundEvent setLivingSound() {
+	public SoundEvent getAmbientSound() {
 		return JourneySounds.BIRD;
 	}
 
 	@Override
-	public SoundEvent setHurtSound() {
+	public SoundEvent getHurtSound(DamageSource sourceIn) {
 		return JourneySounds.BIRD_HURT;
 	}
 
 	@Override
-	public SoundEvent setDeathSound() {
+	public SoundEvent getDeathSound() {
 		return JourneySounds.BIRD_DEATH;
 	}
 
 	@Override
-	public Item getItemDropped() {
+	public Item getDropItem() {
 		return JourneyItems.rocMeat;
 	}
 	@Override

--- a/main/java/net/journey/entity/mob/depths/EntitySpikedBeast.java
+++ b/main/java/net/journey/entity/mob/depths/EntitySpikedBeast.java
@@ -8,6 +8,7 @@ import net.journey.util.PotionEffects;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.Item;
+import net.minecraft.util.DamageSource;
 import net.minecraft.util.SoundEvent;
 import net.minecraft.world.World;
 import net.slayer.api.entity.EntityModMob;
@@ -44,22 +45,22 @@ public class EntitySpikedBeast extends EntityModMob{
 	}
 
 	@Override
-	public SoundEvent setLivingSound() {
+	public SoundEvent getAmbientSound() {
 		return JourneySounds.SPIKED_BEAST;
 	}
 
 	@Override
-	public SoundEvent setHurtSound() {
+	public SoundEvent getHurtSound(DamageSource sourceIn) {
 		return JourneySounds.SPIKED_BEAST_HURT;
 	}
 
 	@Override
-	public SoundEvent setDeathSound() {
+	public SoundEvent getDeathSound() {
 		return JourneySounds.SPIKED_BEAST_HURT;
 	}
 	
 	@Override
-	public Item getItemDropped() {
+	public Item getDropItem() {
 		return null;
 	}
 }

--- a/main/java/net/journey/entity/mob/end/EntityEnderCrawler.java
+++ b/main/java/net/journey/entity/mob/end/EntityEnderCrawler.java
@@ -31,17 +31,17 @@ public class EntityEnderCrawler extends EntityModMob{
 	}
 
 	@Override
-	public SoundEvent setLivingSound() {
+	public SoundEvent getAmbientSound() {
 		return JourneySounds.REAPER;
 	}
 
 	@Override
-	public SoundEvent setHurtSound() {
+	public SoundEvent getHurtSound(DamageSource sourceIn) {
 		return JourneySounds.REAPER_HURT;
 	}
 
 	@Override
-	public SoundEvent setDeathSound() {
+	public SoundEvent getDeathSound() {
 		return JourneySounds.REAPER_HURT;
 	}
 	
@@ -53,7 +53,7 @@ public class EntityEnderCrawler extends EntityModMob{
 	}
 	
 	@Override
-	public Item getItemDropped() {
+	public Item getDropItem() {
 		return null;
 	}
 	

--- a/main/java/net/journey/entity/mob/end/EntityEnderLeaper.java
+++ b/main/java/net/journey/entity/mob/end/EntityEnderLeaper.java
@@ -3,6 +3,7 @@ package net.journey.entity.mob.end;
 import net.journey.JourneySounds;
 import net.journey.entity.MobStats;
 import net.minecraft.item.Item;
+import net.minecraft.util.DamageSource;
 import net.minecraft.util.SoundEvent;
 import net.minecraft.world.World;
 import net.slayer.api.entity.EntityModMob;
@@ -26,17 +27,17 @@ public class EntityEnderLeaper extends EntityModMob {
 	}
 
 	@Override
-	public SoundEvent setLivingSound() {
+	public SoundEvent getAmbientSound() {
 		return JourneySounds.SHIMMERER;
 	}
 
 	@Override
-	public SoundEvent setHurtSound() {
+	public SoundEvent getHurtSound(DamageSource sourceIn) {
 		return JourneySounds.SHIMMERER_HURT;
 	}
 
 	@Override
-	public SoundEvent setDeathSound() {
+	public SoundEvent getDeathSound() {
 		return JourneySounds.SHIMMERER_DEATH;
 	}
 	
@@ -46,7 +47,7 @@ public class EntityEnderLeaper extends EntityModMob {
 	}
 
 	@Override
-	public Item getItemDropped() {
+	public Item getDropItem() {
 		return null;
 	}
 }

--- a/main/java/net/journey/entity/mob/euca/EntityDynaster.java
+++ b/main/java/net/journey/entity/mob/euca/EntityDynaster.java
@@ -32,17 +32,17 @@ public class EntityDynaster extends EntityModMob{
 	}
 
 	@Override
-	public SoundEvent setLivingSound() {
+	public SoundEvent getAmbientSound() {
 		return JourneySounds.DYNASTER;
 	}
 
 	@Override
-	public SoundEvent setHurtSound() {
+	public SoundEvent getHurtSound(DamageSource sourceIn) {
 		return JourneySounds.DYNASTER_HURT;
 	}
 
 	@Override
-	public SoundEvent setDeathSound() {
+	public SoundEvent getDeathSound() {
 		return JourneySounds.DYNASTER_DEATH;
 	}
 	
@@ -64,7 +64,7 @@ public class EntityDynaster extends EntityModMob{
 	}
 
 	@Override
-	public Item getItemDropped() {
+	public Item getDropItem() {
 		return null;
 	}
 }

--- a/main/java/net/journey/entity/mob/euca/EntityEucaCharger.java
+++ b/main/java/net/journey/entity/mob/euca/EntityEucaCharger.java
@@ -4,6 +4,7 @@ import net.journey.JourneyItems;
 import net.journey.JourneySounds;
 import net.journey.entity.MobStats;
 import net.minecraft.item.Item;
+import net.minecraft.util.DamageSource;
 import net.minecraft.util.SoundEvent;
 import net.minecraft.world.World;
 import net.slayer.api.entity.EntityModMob;
@@ -33,17 +34,17 @@ public class EntityEucaCharger extends EntityModMob {
 	}
 
 	@Override
-	public SoundEvent setLivingSound() {
+	public SoundEvent getAmbientSound() {
 		return JourneySounds.HONGO;
 	}
 
 	@Override
-	public SoundEvent setHurtSound() {
+	public SoundEvent getHurtSound(DamageSource sourceIn) {
 		return JourneySounds.SAND_CRAWLER;
 	}
 
 	@Override
-	public SoundEvent setDeathSound() {
+	public SoundEvent getDeathSound() {
 		return JourneySounds.SAND_CRAWLER;
 	}
 	
@@ -58,7 +59,7 @@ public class EntityEucaCharger extends EntityModMob {
 	}
 
 	@Override
-	public Item getItemDropped() {
+	public Item getDropItem() {
 		return null;
 	}
 }

--- a/main/java/net/journey/entity/mob/euca/EntityEucaFighter.java
+++ b/main/java/net/journey/entity/mob/euca/EntityEucaFighter.java
@@ -4,6 +4,7 @@ import net.journey.JourneyItems;
 import net.journey.JourneySounds;
 import net.journey.entity.MobStats;
 import net.minecraft.item.Item;
+import net.minecraft.util.DamageSource;
 import net.minecraft.util.SoundEvent;
 import net.minecraft.world.World;
 import net.slayer.api.entity.EntityModMob;
@@ -28,22 +29,22 @@ public class EntityEucaFighter extends EntityModMob {
 	}
 
 	@Override
-	public SoundEvent setLivingSound() {
+	public SoundEvent getAmbientSound() {
 		return JourneySounds.INSECTO;
 	}
 
 	@Override
-	public SoundEvent setHurtSound() {
+	public SoundEvent getHurtSound(DamageSource sourceIn) {
 		return JourneySounds.INSECTO_HURT;
 	}
 
 	@Override
-	public SoundEvent setDeathSound() {
+	public SoundEvent getDeathSound() {
 		return JourneySounds.INSECTO_HURT;
 	}
 
 	@Override
-	public Item getItemDropped() {
+	public Item getDropItem() {
 		return JourneyItems.eucaMeat;
 	}
 	

--- a/main/java/net/journey/entity/mob/euca/EntityGoldbot.java
+++ b/main/java/net/journey/entity/mob/euca/EntityGoldbot.java
@@ -4,6 +4,7 @@ import net.journey.JourneyItems;
 import net.journey.JourneySounds;
 import net.journey.entity.MobStats;
 import net.minecraft.item.Item;
+import net.minecraft.util.DamageSource;
 import net.minecraft.util.SoundEvent;
 import net.minecraft.world.World;
 import net.slayer.api.entity.EntityModMob;
@@ -27,17 +28,17 @@ public class EntityGoldbot extends EntityModMob {
 	}
 	
 	@Override
-	public SoundEvent setLivingSound() {
+	public SoundEvent getAmbientSound() {
 		return JourneySounds.ROBOT;
 	}
 
 	@Override
-	public SoundEvent setHurtSound() {
+	public SoundEvent getHurtSound(DamageSource sourceIn) {
 		return JourneySounds.ROBOT_HURT;
 	}
 
 	@Override
-	public SoundEvent setDeathSound() {
+	public SoundEvent getDeathSound() {
 		return JourneySounds.ROBOT_DEATH;
 	}
 	
@@ -54,7 +55,7 @@ public class EntityGoldbot extends EntityModMob {
 	}
 
 	@Override
-	public Item getItemDropped() {
+	public Item getDropItem() {
 		return null;
 	}
 }

--- a/main/java/net/journey/entity/mob/euca/EntityGolder.java
+++ b/main/java/net/journey/entity/mob/euca/EntityGolder.java
@@ -37,17 +37,17 @@ public class EntityGolder extends EntityModMob{
 	}
 
 	@Override
-	public SoundEvent setLivingSound() {
+	public SoundEvent getAmbientSound() {
 		return JourneySounds.REAPER;
 	}
 
 	@Override
-	public SoundEvent setHurtSound() {
+	public SoundEvent getHurtSound(DamageSource sourceIn) {
 		return JourneySounds.REAPER_HURT;
 	}
 
 	@Override
-	public SoundEvent setDeathSound() {
+	public SoundEvent getDeathSound() {
 		return JourneySounds.REAPER_HURT;
 	}
 	
@@ -59,7 +59,7 @@ public class EntityGolder extends EntityModMob{
 	}
 	
 	@Override
-	public Item getItemDropped() {
+	public Item getDropItem() {
 		return null;
 	}
 	

--- a/main/java/net/journey/entity/mob/euca/EntityGolditeMage.java
+++ b/main/java/net/journey/entity/mob/euca/EntityGolditeMage.java
@@ -17,6 +17,7 @@ import net.minecraft.inventory.EntityEquipmentSlot;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.util.DamageSource;
 import net.minecraft.util.EnumHand;
 import net.minecraft.util.SoundEvent;
 import net.minecraft.util.math.MathHelper;
@@ -104,22 +105,22 @@ public class EntityGolditeMage extends EntityModMob implements IRangedAttackMob 
 	}
 
 	@Override
-	public SoundEvent setLivingSound() {
+	public SoundEvent getAmbientSound() {
 		return JourneySounds.PSYOLLOM;
 	}
 
 	@Override
-	public SoundEvent setHurtSound() {
+	public SoundEvent getHurtSound(DamageSource sourceIn) {
 		return JourneySounds.INSECTO_HURT;
 	}
 
 	@Override
-	public SoundEvent setDeathSound() {
+	public SoundEvent getDeathSound() {
 		return JourneySounds.INSECTO_HURT;
 	}
 
 	@Override
-	public Item getItemDropped() {
+	public Item getDropItem() {
 		return null;
 	}
 

--- a/main/java/net/journey/entity/mob/euca/EntityGoldwing.java
+++ b/main/java/net/journey/entity/mob/euca/EntityGoldwing.java
@@ -4,6 +4,7 @@ import net.journey.JourneyItems;
 import net.journey.JourneySounds;
 import net.journey.entity.MobStats;
 import net.minecraft.item.Item;
+import net.minecraft.util.DamageSource;
 import net.minecraft.util.SoundEvent;
 import net.minecraft.world.World;
 import net.slayer.api.entity.EntityPeacefullUntillAttacked;
@@ -25,22 +26,22 @@ public class EntityGoldwing extends EntityPeacefullUntillAttacked {
 	}
 
 	@Override
-	public SoundEvent setLivingSound() {
+	public SoundEvent getAmbientSound() {
 		return JourneySounds.BIRD;
 	}
 
 	@Override
-	public SoundEvent setHurtSound() {
+	public SoundEvent getHurtSound(DamageSource sourceIn) {
 		return JourneySounds.BIRD_HURT;
 	}
 
 	@Override
-	public SoundEvent setDeathSound() {
+	public SoundEvent getDeathSound() {
 		return JourneySounds.BIRD_DEATH;
 	}
 	
 	@Override
-	public Item getItemDropped() {
+	public Item getDropItem() {
 		return JourneyItems.rocMeat;
 	}
 	

--- a/main/java/net/journey/entity/mob/euca/EntityInsecto.java
+++ b/main/java/net/journey/entity/mob/euca/EntityInsecto.java
@@ -37,17 +37,17 @@ public class EntityInsecto extends EntityModMob{
 	}
 
 	@Override
-	public SoundEvent setLivingSound() {
+	public SoundEvent getAmbientSound() {
 		return JourneySounds.INSECTO;
 	}
 
 	@Override
-	public SoundEvent setHurtSound() {
+	public SoundEvent getHurtSound(DamageSource sourceIn) {
 		return JourneySounds.INSECTO_HURT;
 	}
 
 	@Override
-	public SoundEvent setDeathSound() {
+	public SoundEvent getDeathSound() {
 		return JourneySounds.INSECTO_HURT;
 	}
 	
@@ -59,7 +59,7 @@ public class EntityInsecto extends EntityModMob{
 	}
 	
 	@Override
-	public Item getItemDropped() {
+	public Item getDropItem() {
 		return JourneyItems.eucaMeat;
 	}
 	

--- a/main/java/net/journey/entity/mob/euca/EntityPsyollom.java
+++ b/main/java/net/journey/entity/mob/euca/EntityPsyollom.java
@@ -4,6 +4,7 @@ import net.journey.JourneyItems;
 import net.journey.JourneySounds;
 import net.journey.entity.MobStats;
 import net.minecraft.item.Item;
+import net.minecraft.util.DamageSource;
 import net.minecraft.util.SoundEvent;
 import net.minecraft.world.World;
 import net.slayer.api.entity.EntityModMob;
@@ -29,22 +30,22 @@ public class EntityPsyollom extends EntityModMob {
 	}
 
 	@Override
-	public SoundEvent setLivingSound() {
+	public SoundEvent getAmbientSound() {
 		return JourneySounds.PSYOLLOM;
 	}
 
 	@Override
-	public SoundEvent setHurtSound() {
+	public SoundEvent getHurtSound(DamageSource sourceIn) {
 		return JourneySounds.PSYOLLOM_HURT;
 	}
 
 	@Override
-	public SoundEvent setDeathSound() {
+	public SoundEvent getDeathSound() {
 		return JourneySounds.PSYOLLOM_HURT;
 	}
 	
 	@Override
-	public Item getItemDropped() {
+	public Item getDropItem() {
 		return JourneyItems.eucaMeat;
 	}
 	

--- a/main/java/net/journey/entity/mob/euca/EntityShimmerer.java
+++ b/main/java/net/journey/entity/mob/euca/EntityShimmerer.java
@@ -14,6 +14,7 @@ import net.minecraft.item.Item;
 import net.minecraft.network.datasync.DataParameter;
 import net.minecraft.network.datasync.DataSerializers;
 import net.minecraft.network.datasync.EntityDataManager;
+import net.minecraft.util.DamageSource;
 import net.minecraft.util.SoundEvent;
 import net.minecraft.util.math.AxisAlignedBB;
 import net.minecraft.util.math.MathHelper;
@@ -48,17 +49,17 @@ public class EntityShimmerer extends EntityModFlying {
     }
 	
 	@Override
-	public SoundEvent setLivingSound() {
+	public SoundEvent getAmbientSound() {
 		return JourneySounds.SHIMMERER;
 	}
 
 	@Override
-	public SoundEvent setHurtSound() {
+	public SoundEvent getHurtSound(DamageSource sourceIn) {
 		return JourneySounds.SHIMMERER_HURT;
 	}
 
 	@Override
-	public SoundEvent setDeathSound() {
+	public SoundEvent getDeathSound() {
 		return JourneySounds.SHIMMERER_DEATH;
 	}
 	
@@ -96,7 +97,7 @@ public class EntityShimmerer extends EntityModFlying {
 	}
 
 	@Override
-	public Item getItemDropped() {
+	public Item getDropItem() {
 		return null;
 	}
 

--- a/main/java/net/journey/entity/mob/euca/EntitySilverbot.java
+++ b/main/java/net/journey/entity/mob/euca/EntitySilverbot.java
@@ -4,6 +4,7 @@ import net.journey.JourneyItems;
 import net.journey.JourneySounds;
 import net.journey.entity.MobStats;
 import net.minecraft.item.Item;
+import net.minecraft.util.DamageSource;
 import net.minecraft.util.SoundEvent;
 import net.minecraft.world.World;
 import net.slayer.api.entity.EntityModMob;
@@ -27,17 +28,17 @@ public class EntitySilverbot extends EntityModMob {
 	}
 
 	@Override
-	public SoundEvent setLivingSound() {
+	public SoundEvent getAmbientSound() {
 		return JourneySounds.ROBOT;
 	}
 
 	@Override
-	public SoundEvent setHurtSound() {
+	public SoundEvent getHurtSound(DamageSource sourceIn) {
 		return JourneySounds.ROBOT_HURT;
 	}
 
 	@Override
-	public SoundEvent setDeathSound() {
+	public SoundEvent getDeathSound() {
 		return JourneySounds.ROBOT_DEATH;
 	}
 	
@@ -54,7 +55,7 @@ public class EntitySilverbot extends EntityModMob {
 	}
 
 	@Override
-	public Item getItemDropped() {
+	public Item getDropItem() {
 		return null;
 	}
 }

--- a/main/java/net/journey/entity/mob/frozen/EntityCrystalCluster.java
+++ b/main/java/net/journey/entity/mob/frozen/EntityCrystalCluster.java
@@ -14,6 +14,7 @@ import net.minecraft.item.Item;
 import net.minecraft.network.datasync.DataParameter;
 import net.minecraft.network.datasync.DataSerializers;
 import net.minecraft.network.datasync.EntityDataManager;
+import net.minecraft.util.DamageSource;
 import net.minecraft.util.SoundEvent;
 import net.minecraft.util.math.AxisAlignedBB;
 import net.minecraft.util.math.MathHelper;
@@ -49,17 +50,17 @@ public class EntityCrystalCluster extends EntityModFlying {
     }
 
 	@Override
-	public SoundEvent setLivingSound() {
+	public SoundEvent getAmbientSound() {
 		return JourneySounds.SHIMMERER;
 	}
 
 	@Override
-	public SoundEvent setHurtSound() {
+	public SoundEvent getHurtSound(DamageSource sourceIn) {
 		return JourneySounds.SHIMMERER_HURT;
 	}
 
 	@Override
-	public SoundEvent setDeathSound() {
+	public SoundEvent getDeathSound() {
 		return JourneySounds.SHIMMERER_DEATH;
 	}
 	
@@ -86,7 +87,7 @@ public class EntityCrystalCluster extends EntityModFlying {
 	}
 
 	@Override
-	public Item getItemDropped() {
+	public Item getDropItem() {
 		return null;
 	}
 

--- a/main/java/net/journey/entity/mob/frozen/EntityFrozenFrostbiter.java
+++ b/main/java/net/journey/entity/mob/frozen/EntityFrozenFrostbiter.java
@@ -147,22 +147,22 @@ public class EntityFrozenFrostbiter extends EntityModMob {
 	}
 
 	@Override
-	public SoundEvent setLivingSound() {
+	public SoundEvent getAmbientSound() {
 		return SoundEvents.ENTITY_BLAZE_AMBIENT;
 	}
 
 	@Override
-	public SoundEvent setHurtSound() {
+	public SoundEvent getHurtSound(DamageSource sourceIn) {
 		return SoundEvents.ENTITY_BLAZE_HURT;
 	}
 
 	@Override
-	public SoundEvent setDeathSound() {
+	public SoundEvent getDeathSound() {
 		return SoundEvents.ENTITY_BLAZE_DEATH;
 	}
 
 	@Override
-	public Item getItemDropped() {
+	public Item getDropItem() {
 		return Items.BLAZE_ROD;
 	}
 

--- a/main/java/net/journey/entity/mob/frozen/EntityFrozenTroll.java
+++ b/main/java/net/journey/entity/mob/frozen/EntityFrozenTroll.java
@@ -8,6 +8,7 @@ import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.SharedMonsterAttributes;
 import net.minecraft.item.Item;
 import net.minecraft.potion.PotionEffect;
+import net.minecraft.util.DamageSource;
 import net.minecraft.util.SoundEvent;
 import net.minecraft.util.math.MathHelper;
 import net.minecraft.world.World;
@@ -49,17 +50,17 @@ public class EntityFrozenTroll extends EntityModMob {
 	}
 
 	@Override
-	public SoundEvent setLivingSound() {
+	public SoundEvent getAmbientSound() {
 		return JourneySounds.SMALL_HONGO;
 	}
 
 	@Override
-	public SoundEvent setHurtSound() {
+	public SoundEvent getHurtSound(DamageSource sourceIn) {
 		return JourneySounds.SMALL_HONGO_HURT;
 	}
 
 	@Override
-	public SoundEvent setDeathSound() {
+	public SoundEvent getDeathSound() {
 		return JourneySounds.SMALL_HONGO_HURT;
 	}
 
@@ -69,7 +70,7 @@ public class EntityFrozenTroll extends EntityModMob {
 	}
 	
 	@Override
-	public Item getItemDropped() {
+	public Item getDropItem() {
 		return null;
 	}
 }

--- a/main/java/net/journey/entity/mob/frozen/EntityPermafraust.java
+++ b/main/java/net/journey/entity/mob/frozen/EntityPermafraust.java
@@ -3,6 +3,7 @@ package net.journey.entity.mob.frozen;
 import net.journey.JourneySounds;
 import net.journey.entity.MobStats;
 import net.minecraft.item.Item;
+import net.minecraft.util.DamageSource;
 import net.minecraft.util.SoundEvent;
 import net.minecraft.world.World;
 import net.slayer.api.entity.EntityModMob;
@@ -26,17 +27,17 @@ public class EntityPermafraust extends EntityModMob {
 	}
 
 	@Override
-	public SoundEvent setLivingSound() {
+	public SoundEvent getAmbientSound() {
 		return JourneySounds.SMALL_HONGO;
 	}
 
 	@Override
-	public SoundEvent setHurtSound() {
+	public SoundEvent getHurtSound(DamageSource sourceIn) {
 		return JourneySounds.SMALL_HONGO_HURT;
 	}
 
 	@Override
-	public SoundEvent setDeathSound() {
+	public SoundEvent getDeathSound() {
 		return JourneySounds.SMALL_HONGO_HURT;
 	}
 	
@@ -51,7 +52,7 @@ public class EntityPermafraust extends EntityModMob {
 	}
 
 	@Override
-	public Item getItemDropped() {
+	public Item getDropItem() {
 		return null;
 	}
 }

--- a/main/java/net/journey/entity/mob/frozen/EntityShatterer.java
+++ b/main/java/net/journey/entity/mob/frozen/EntityShatterer.java
@@ -8,6 +8,7 @@ import net.journey.entity.MobStats;
 import net.minecraft.entity.ai.EntityAIBase;
 import net.minecraft.entity.ai.EntityMoveHelper;
 import net.minecraft.item.Item;
+import net.minecraft.util.DamageSource;
 import net.minecraft.util.SoundEvent;
 import net.minecraft.util.math.AxisAlignedBB;
 import net.minecraft.util.math.BlockPos;
@@ -37,22 +38,22 @@ public class EntityShatterer extends EntityModFlying {
 	}
 
 	@Override
-	public SoundEvent setLivingSound() {
+	public SoundEvent getAmbientSound() {
 		return JourneySounds.HONGO;
 	}
 
 	@Override
-	public SoundEvent setHurtSound() {
+	public SoundEvent getHurtSound(DamageSource sourceIn) {
 		return JourneySounds.SAND_CRAWLER;
 	}
 
 	@Override
-	public SoundEvent setDeathSound() {
+	public SoundEvent getDeathSound() {
 		return JourneySounds.SAND_CRAWLER;
 	}
 	
 	@Override
-	public Item getItemDropped() {
+	public Item getDropItem() {
 		return null;
 	}
 	

--- a/main/java/net/journey/entity/mob/frozen/EntityShiveringBushwalker.java
+++ b/main/java/net/journey/entity/mob/frozen/EntityShiveringBushwalker.java
@@ -3,6 +3,7 @@ package net.journey.entity.mob.frozen;
 import net.journey.JourneySounds;
 import net.journey.entity.MobStats;
 import net.minecraft.item.Item;
+import net.minecraft.util.DamageSource;
 import net.minecraft.util.SoundEvent;
 import net.minecraft.world.World;
 import net.slayer.api.entity.EntityModMob;
@@ -13,6 +14,7 @@ public class EntityShiveringBushwalker extends EntityModMob {
 		super(par1World);
 		addAttackingAI();
 		this.setSize(0.65F, 1F);
+
 	}
 
 	@Override
@@ -26,27 +28,22 @@ public class EntityShiveringBushwalker extends EntityModMob {
 	}
 
 	@Override
-	public SoundEvent setLivingSound() {
+	public SoundEvent getAmbientSound() {
 		return JourneySounds.SMALL_HONGO;
 	}
 
 	@Override
-	public SoundEvent setHurtSound() {
+	public SoundEvent getHurtSound(DamageSource sourceIn) {
 		return JourneySounds.SMALL_HONGO_HURT;
 	}
 
 	@Override
-	public SoundEvent setDeathSound() {
+	public SoundEvent getDeathSound() {
 		return JourneySounds.SMALL_HONGO_HURT;
 	}
 	
 	@Override
 	public boolean getCanSpawnHere() {
 		return this.posY < 60.0D && super.getCanSpawnHere();
-	}
-	
-	@Override
-	public Item getItemDropped() {
-		return null;
 	}
 }

--- a/main/java/net/journey/entity/mob/frozen/EntityShiveringShrieker.java
+++ b/main/java/net/journey/entity/mob/frozen/EntityShiveringShrieker.java
@@ -3,6 +3,7 @@ package net.journey.entity.mob.frozen;
 import net.journey.JourneySounds;
 import net.journey.entity.MobStats;
 import net.minecraft.item.Item;
+import net.minecraft.util.DamageSource;
 import net.minecraft.util.SoundEvent;
 import net.minecraft.world.World;
 import net.slayer.api.entity.EntityModMob;
@@ -26,17 +27,17 @@ public class EntityShiveringShrieker extends EntityModMob {
 	}
 
 	@Override
-	public SoundEvent setLivingSound() {
+	public SoundEvent getAmbientSound() {
 		return JourneySounds.SMALL_HONGO;
 	}
 
 	@Override
-	public SoundEvent setHurtSound() {
+	public SoundEvent getHurtSound(DamageSource sourceIn) {
 		return JourneySounds.SMALL_HONGO_HURT;
 	}
 
 	@Override
-	public SoundEvent setDeathSound() {
+	public SoundEvent getDeathSound() {
 		return JourneySounds.SMALL_HONGO_HURT;
 	}
 	
@@ -46,7 +47,7 @@ public class EntityShiveringShrieker extends EntityModMob {
 	}
 	
 	@Override
-	public Item getItemDropped() {
+	public Item getDropItem() {
 		return null;
 	}
 }

--- a/main/java/net/journey/entity/mob/frozen/EntityShiverwing.java
+++ b/main/java/net/journey/entity/mob/frozen/EntityShiverwing.java
@@ -4,6 +4,7 @@ import net.journey.JourneyItems;
 import net.journey.JourneySounds;
 import net.journey.entity.MobStats;
 import net.minecraft.item.Item;
+import net.minecraft.util.DamageSource;
 import net.minecraft.util.SoundEvent;
 import net.minecraft.world.World;
 import net.slayer.api.entity.EntityPeacefullUntillAttacked;
@@ -25,22 +26,22 @@ public class EntityShiverwing extends EntityPeacefullUntillAttacked {
 	}
 
 	@Override
-	public SoundEvent setLivingSound() {
+	public SoundEvent getAmbientSound() {
 		return JourneySounds.BIRD;
 	}
 
 	@Override
-	public SoundEvent setHurtSound() {
+	public SoundEvent getHurtSound(DamageSource sourceIn) {
 		return JourneySounds.BIRD_HURT;
 	}
 
 	@Override
-	public SoundEvent setDeathSound() {
+	public SoundEvent getDeathSound() {
 		return JourneySounds.BIRD_DEATH;
 	}
 
 	@Override
-	public Item getItemDropped() {
+	public Item getDropItem() {
 		return JourneyItems.rocMeat;
 	}
 	

--- a/main/java/net/journey/entity/mob/nether/EntityHellCow.java
+++ b/main/java/net/journey/entity/mob/nether/EntityHellCow.java
@@ -82,7 +82,7 @@ public class EntityHellCow extends EntityPeacefullUntillAttacked {
     }
 	
 	@Override
-	public Item getItemDropped() {
+	public Item getDropItem() {
 		return JourneyItems.flamingHide;
 	}
 	
@@ -139,20 +139,5 @@ public class EntityHellCow extends EntityPeacefullUntillAttacked {
 			if(rand.nextInt(1) == 0)dropItem(JourneyItems.flamingBeef, 1); 
 			}
 		super.dropFewItems(b, j);
-	}
-
-	@Override
-	public SoundEvent setLivingSound() {
-		return JourneySounds.EMPTY;
-	}
-
-	@Override
-	public SoundEvent setHurtSound() {
-		return JourneySounds.EMPTY;
-	}
-
-	@Override
-	public SoundEvent setDeathSound() {
-		return JourneySounds.EMPTY;
 	}
 }

--- a/main/java/net/journey/entity/mob/nether/EntityHellTurtle.java
+++ b/main/java/net/journey/entity/mob/nether/EntityHellTurtle.java
@@ -9,6 +9,7 @@ import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.SharedMonsterAttributes;
 import net.minecraft.item.Item;
 import net.minecraft.potion.PotionEffect;
+import net.minecraft.util.DamageSource;
 import net.minecraft.util.SoundEvent;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.MathHelper;
@@ -62,22 +63,22 @@ public class EntityHellTurtle extends EntityModMob {
 	}
 
 	@Override
-	public SoundEvent setLivingSound() {
+	public SoundEvent getAmbientSound() {
 		return JourneySounds.SMALL_HONGO;
 	}
 
 	@Override
-	public SoundEvent setHurtSound() {
+	public SoundEvent getHurtSound(DamageSource sourceIn) {
 		return JourneySounds.SMALL_HONGO_HURT;
 	}
 
 	@Override
-	public SoundEvent setDeathSound() {
+	public SoundEvent getDeathSound() {
 		return JourneySounds.SMALL_HONGO_HURT;
 	}
 	
 	@Override
-	public Item getItemDropped() {
+	public Item getDropItem() {
 		return null;
 	}
 }

--- a/main/java/net/journey/entity/mob/nether/EntityHellbot.java
+++ b/main/java/net/journey/entity/mob/nether/EntityHellbot.java
@@ -4,6 +4,7 @@ import net.journey.JourneyItems;
 import net.journey.JourneySounds;
 import net.journey.entity.MobStats;
 import net.minecraft.item.Item;
+import net.minecraft.util.DamageSource;
 import net.minecraft.util.SoundEvent;
 import net.minecraft.world.World;
 import net.slayer.api.entity.EntityModMob;
@@ -27,17 +28,17 @@ public class EntityHellbot extends EntityModMob {
 	}
 
 	@Override
-	public SoundEvent setLivingSound() {
+	public SoundEvent getAmbientSound() {
 		return JourneySounds.ROBOT;
 	}
 
 	@Override
-	public SoundEvent setHurtSound() {
+	public SoundEvent getHurtSound(DamageSource sourceIn) {
 		return JourneySounds.ROBOT_HURT;
 	}
 
 	@Override
-	public SoundEvent setDeathSound() {
+	public SoundEvent getDeathSound() {
 		return JourneySounds.ROBOT_DEATH;
 	}
 	
@@ -51,7 +52,7 @@ public class EntityHellbot extends EntityModMob {
 	}
 
 	@Override
-	public Item getItemDropped() {
+	public Item getDropItem() {
 		return null;
 	}
 }

--- a/main/java/net/journey/entity/mob/nether/EntityInfernoBlaze.java
+++ b/main/java/net/journey/entity/mob/nether/EntityInfernoBlaze.java
@@ -224,22 +224,7 @@ public class EntityInfernoBlaze extends EntityModMob {
 	}
 
 	@Override
-	public SoundEvent setLivingSound() {
-		return SoundEvents.ENTITY_BLAZE_AMBIENT;
-	}
-
-	@Override
-	public SoundEvent setHurtSound() {
-		return SoundEvents.ENTITY_BLAZE_HURT;
-	}
-
-	@Override
-	public SoundEvent setDeathSound() {
-		return SoundEvents.ENTITY_BLAZE_DEATH;
-	}
-
-	@Override
-	public Item getItemDropped() {
+	public Item getDropItem() {
 		return Items.BLAZE_ROD;
 	}
 	

--- a/main/java/net/journey/entity/mob/nether/EntityLavasnake.java
+++ b/main/java/net/journey/entity/mob/nether/EntityLavasnake.java
@@ -87,7 +87,7 @@ public class EntityLavasnake extends EntityModFlying {
 	}
 
 	@Override
-	public Item getItemDropped() {
+	public Item getDropItem() {
 		return null;
 	}
 
@@ -356,24 +356,6 @@ public class EntityLavasnake extends EntityModFlying {
 
 			return true;
 		}
-	}
-
-	@Override
-	public SoundEvent setLivingSound() {
-		// TODO Auto-generated method stub
-		return null;
-	}
-
-	@Override
-	public SoundEvent setHurtSound() {
-		// TODO Auto-generated method stub
-		return null;
-	}
-
-	@Override
-	public SoundEvent setDeathSound() {
-		// TODO Auto-generated method stub
-		return null;
 	}
 
 	@Override

--- a/main/java/net/journey/entity/mob/nether/EntityMiniGhast.java
+++ b/main/java/net/journey/entity/mob/nether/EntityMiniGhast.java
@@ -72,7 +72,7 @@ public class EntityMiniGhast extends EntityModFlying {
 	}
 
 	@Override
-	public Item getItemDropped() {
+	public Item getDropItem() {
 		return null;
 	}
 
@@ -343,23 +343,4 @@ public class EntityMiniGhast extends EntityModFlying {
 			return true;
 		}
 	}
-
-	@Override
-	public SoundEvent setLivingSound() {
-		// TODO Auto-generated method stub
-		return null;
-	}
-
-	@Override
-	public SoundEvent setHurtSound() {
-		// TODO Auto-generated method stub
-		return null;
-	}
-
-	@Override
-	public SoundEvent setDeathSound() {
-		// TODO Auto-generated method stub
-		return null;
-	}
-
 }

--- a/main/java/net/journey/entity/mob/nether/EntityReaper.java
+++ b/main/java/net/journey/entity/mob/nether/EntityReaper.java
@@ -70,7 +70,7 @@ public class EntityReaper extends EntityModMob {
     }
 	
 	@Override
-	public Item getItemDropped() {
+	public Item getDropItem() {
 		return JourneyItems.withicDust;
 	}
 	
@@ -82,20 +82,5 @@ public class EntityReaper extends EntityModMob {
 		if(rand.nextInt(22) == 0) dropItem(JourneyItems.lostSoul, 1);
 		if(rand.nextInt(33) == 0) dropItem(JourneyItems.lostSoul, 2);
 		super.dropFewItems(b, j);
-	}
-
-	@Override
-	public SoundEvent setLivingSound() {
-		return JourneySounds.EMPTY;
-	}
-
-	@Override
-	public SoundEvent setHurtSound() {
-		return JourneySounds.EMPTY;
-	}
-
-	@Override
-	public SoundEvent setDeathSound() {
-		return JourneySounds.EMPTY;
 	}
 }

--- a/main/java/net/journey/entity/mob/nether/EntityWitherspine.java
+++ b/main/java/net/journey/entity/mob/nether/EntityWitherspine.java
@@ -55,11 +55,6 @@ public class EntityWitherspine extends EntityModMob {
 	}
 
 	@Override
-	public SoundEvent setLivingSound() {
-		return JourneySounds.EMPTY;
-	}
-
-	@Override
     protected SoundEvent getAmbientSound() {
         return SoundEvents.ENTITY_WITHER_AMBIENT;
     }
@@ -73,16 +68,6 @@ public class EntityWitherspine extends EntityModMob {
     protected SoundEvent getDeathSound() {
         return SoundEvents.ENTITY_SKELETON_DEATH;
     }
-    
-	@Override
-	public SoundEvent setHurtSound() {
-		return JourneySounds.EMPTY;
-	}
-
-	@Override
-	public SoundEvent setDeathSound() {
-		return JourneySounds.EMPTY;
-	}
 	
 	@Override
 	protected void dropFewItems(boolean b, int j) {
@@ -99,7 +84,7 @@ public class EntityWitherspine extends EntityModMob {
 	}
 
 	@Override
-	public Item getItemDropped() {
+	public Item getDropItem() {
 		return null;
 	}
 }

--- a/main/java/net/journey/entity/mob/overworld/EntityBigHongo.java
+++ b/main/java/net/journey/entity/mob/overworld/EntityBigHongo.java
@@ -4,6 +4,7 @@ import net.journey.JourneyItems;
 import net.journey.JourneySounds;
 import net.journey.entity.MobStats;
 import net.minecraft.item.Item;
+import net.minecraft.util.DamageSource;
 import net.minecraft.util.SoundEvent;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
@@ -28,17 +29,17 @@ public class EntityBigHongo extends EntityModMob {
 	}
 
 	@Override
-	public SoundEvent setLivingSound() {
+	public SoundEvent getAmbientSound() {
 		return JourneySounds.HONGO;
 	}
 
 	@Override
-	public SoundEvent setHurtSound() {
+	public SoundEvent getHurtSound(DamageSource sourceIn) {
 		return JourneySounds.HONGO_HURT;
 	}
 
 	@Override
-	public SoundEvent setDeathSound() {
+	public SoundEvent getDeathSound() {
 		return JourneySounds.HONGO_HURT;
 	}
 	
@@ -49,7 +50,7 @@ public class EntityBigHongo extends EntityModMob {
 	}
 
 	@Override
-	public Item getItemDropped() {
+	public Item getDropItem() {
 		return JourneyItems.hongoShroom;
 	}
 }

--- a/main/java/net/journey/entity/mob/overworld/EntityBoom.java
+++ b/main/java/net/journey/entity/mob/overworld/EntityBoom.java
@@ -20,6 +20,7 @@ import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.network.datasync.DataParameter;
 import net.minecraft.network.datasync.DataSerializers;
 import net.minecraft.network.datasync.EntityDataManager;
+import net.minecraft.util.DamageSource;
 import net.minecraft.util.EnumHand;
 import net.minecraft.util.SoundEvent;
 import net.minecraft.util.math.BlockPos;
@@ -96,17 +97,17 @@ public class EntityBoom extends EntityModMob {
 	}
 
 	@Override
-	public SoundEvent setLivingSound() {
+	public SoundEvent getAmbientSound() {
 		return SoundEvents.ENTITY_CREEPER_PRIMED;
 	}
 
 	@Override
-	public SoundEvent setHurtSound() {
+	public SoundEvent getHurtSound(DamageSource sourceIn) {
 		return SoundEvents.ENTITY_CREEPER_HURT;
 	}
 
 	@Override
-	public SoundEvent setDeathSound() {
+	public SoundEvent getDeathSound() {
 		return SoundEvents.ENTITY_CREEPER_DEATH;
 	}
 
@@ -118,7 +119,7 @@ public class EntityBoom extends EntityModMob {
 	}
 	
 	@Override
-	public Item getItemDropped() {
+	public Item getDropItem() {
 		return null;
 	}
 

--- a/main/java/net/journey/entity/mob/overworld/EntityDunewerm.java
+++ b/main/java/net/journey/entity/mob/overworld/EntityDunewerm.java
@@ -4,6 +4,7 @@ import net.journey.JourneySounds;
 import net.journey.entity.MobStats;
 import net.minecraft.init.Blocks;
 import net.minecraft.item.Item;
+import net.minecraft.util.DamageSource;
 import net.minecraft.util.SoundEvent;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
@@ -29,22 +30,22 @@ public class EntityDunewerm extends EntityModMob {
 	}
 
 	@Override
-	public SoundEvent setLivingSound() {
+	public SoundEvent getAmbientSound() {
 		return JourneySounds.SAND_CRAWLER;
 	}
 
 	@Override
-	public SoundEvent setHurtSound() {
+	public SoundEvent getHurtSound(DamageSource sourceIn) {
 		return JourneySounds.MAGMA_GIANT_HURT;
 	}
 
 	@Override
-	public SoundEvent setDeathSound() {
+	public SoundEvent getDeathSound() {
 		return JourneySounds.MAGMA_GIANT_HURT;
 	}
 
 	@Override
-	public Item getItemDropped() {
+	public Item getDropItem() {
 		return null;
 	}
 	

--- a/main/java/net/journey/entity/mob/overworld/EntityFireMage.java
+++ b/main/java/net/journey/entity/mob/overworld/EntityFireMage.java
@@ -17,6 +17,7 @@ import net.minecraft.inventory.EntityEquipmentSlot;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.util.DamageSource;
 import net.minecraft.util.EnumHand;
 import net.minecraft.util.SoundEvent;
 import net.minecraft.util.math.BlockPos;
@@ -119,22 +120,22 @@ public class EntityFireMage extends EntityModMob implements IRangedAttackMob {
 	}
 
 	@Override
-	public SoundEvent setLivingSound() {
+	public SoundEvent getAmbientSound() {
 		return JourneySounds.INSECTO;
 	}
 
 	@Override
-	public SoundEvent setHurtSound() {
+	public SoundEvent getHurtSound(DamageSource sourceIn) {
 		return JourneySounds.INSECTO_HURT;
 	}
 
 	@Override
-	public SoundEvent setDeathSound() {
+	public SoundEvent getDeathSound() {
 		return JourneySounds.INSECTO_HURT;
 	}
 
 	@Override
-	public Item getItemDropped() {
+	public Item getDropItem() {
 		return null;
 	}
 

--- a/main/java/net/journey/entity/mob/overworld/EntityFloro.java
+++ b/main/java/net/journey/entity/mob/overworld/EntityFloro.java
@@ -123,29 +123,9 @@ public class EntityFloro extends EntityModMob implements IRangedAttackMob {
 
 	@Override
 	protected SoundEvent getDeathSound() {
-		return JourneySounds.BIRD_DEATH;
-	}
-	
-	@Override
-	public SoundEvent setLivingSound() {
-		return JourneySounds.HONGO;
-	}
-
-	@Override
-	public SoundEvent setHurtSound() {
 		return JourneySounds.HONGO_HURT;
 	}
 
-	@Override
-	public SoundEvent setDeathSound() {
-		return JourneySounds.HONGO;
-	}
-	
-	@Override
-	public Item getItemDropped() {
-		return null;
-	}
-	
 	@Override
 	protected void dropFewItems(boolean b, int j) {
 		if(rand.nextInt(16) == 0) dropItem(JourneyItems.floroPedal, rand.nextInt(3));

--- a/main/java/net/journey/entity/mob/overworld/EntityIceMage.java
+++ b/main/java/net/journey/entity/mob/overworld/EntityIceMage.java
@@ -18,6 +18,7 @@ import net.minecraft.inventory.EntityEquipmentSlot;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.util.DamageSource;
 import net.minecraft.util.EnumHand;
 import net.minecraft.util.SoundEvent;
 import net.minecraft.util.math.BlockPos;
@@ -123,22 +124,22 @@ public class EntityIceMage extends EntityModMob implements IRangedAttackMob {
 	}
 
 	@Override
-	public SoundEvent setLivingSound() {
+	public SoundEvent getAmbientSound() {
 		return JourneySounds.INSECTO;
 	}
 
 	@Override
-	public SoundEvent setHurtSound() {
+	public SoundEvent getHurtSound(DamageSource sourceIn) {
 		return JourneySounds.INSECTO_HURT;
 	}
 
 	@Override
-	public SoundEvent setDeathSound() {
+	public SoundEvent getDeathSound() {
 		return JourneySounds.INSECTO_HURT;
 	}
 
 	@Override
-	public Item getItemDropped() {
+	public Item getDropItem() {
 		return null;
 	}
 

--- a/main/java/net/journey/entity/mob/overworld/EntityMediumHongo.java
+++ b/main/java/net/journey/entity/mob/overworld/EntityMediumHongo.java
@@ -4,6 +4,7 @@ import net.journey.JourneyItems;
 import net.journey.JourneySounds;
 import net.journey.entity.MobStats;
 import net.minecraft.item.Item;
+import net.minecraft.util.DamageSource;
 import net.minecraft.util.SoundEvent;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
@@ -28,17 +29,17 @@ public class EntityMediumHongo extends EntityModMob {
 	}
 	
 	@Override
-	public SoundEvent setLivingSound() {
+	public SoundEvent getAmbientSound() {
 		return JourneySounds.HONGO;
 	}
 
 	@Override
-	public SoundEvent setHurtSound() {
+	public SoundEvent getHurtSound(DamageSource sourceIn) {
 		return JourneySounds.HONGO_HURT;
 	}
 
 	@Override
-	public SoundEvent setDeathSound() {
+	public SoundEvent getDeathSound() {
 		return JourneySounds.HONGO_HURT;
 	}
 	
@@ -49,7 +50,7 @@ public class EntityMediumHongo extends EntityModMob {
 	}
 	
 	@Override
-	public Item getItemDropped() {
+	public Item getDropItem() {
 		return JourneyItems.hongoShroom;
 	}
 }

--- a/main/java/net/journey/entity/mob/overworld/EntityRobot.java
+++ b/main/java/net/journey/entity/mob/overworld/EntityRobot.java
@@ -5,6 +5,7 @@ import net.journey.entity.MobStats;
 import net.minecraft.init.Blocks;
 import net.minecraft.init.Items;
 import net.minecraft.item.Item;
+import net.minecraft.util.DamageSource;
 import net.minecraft.util.SoundEvent;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
@@ -29,17 +30,17 @@ public class EntityRobot extends EntityModMob {
 	}
 
 	@Override
-	public SoundEvent setLivingSound() {
+	public SoundEvent getAmbientSound() {
 		return JourneySounds.ROBOT;
 	}
 
 	@Override
-	public SoundEvent setHurtSound() {
+	public SoundEvent getHurtSound(DamageSource sourceIn) {
 		return JourneySounds.ROBOT_HURT;
 	}
 
 	@Override
-	public SoundEvent setDeathSound() {
+	public SoundEvent getDeathSound() {
 		return JourneySounds.ROBOT_HURT;
 	}
 	
@@ -59,7 +60,7 @@ public class EntityRobot extends EntityModMob {
 	}
 
 	@Override
-	public Item getItemDropped() {
+	public Item getDropItem() {
 		return null;
 	}
 }

--- a/main/java/net/journey/entity/mob/overworld/EntitySandCrawler.java
+++ b/main/java/net/journey/entity/mob/overworld/EntitySandCrawler.java
@@ -4,6 +4,7 @@ import net.journey.JourneySounds;
 import net.journey.entity.MobStats;
 import net.minecraft.init.Blocks;
 import net.minecraft.item.Item;
+import net.minecraft.util.DamageSource;
 import net.minecraft.util.SoundEvent;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
@@ -29,22 +30,22 @@ public class EntitySandCrawler extends EntityModMob {
 	}
 
 	@Override
-	public SoundEvent setLivingSound() {
+	public SoundEvent getAmbientSound() {
 		return JourneySounds.SAND_CRAWLER;
 	}
 
 	@Override
-	public SoundEvent setHurtSound() {
+	public SoundEvent getHurtSound(DamageSource sourceIn) {
 		return JourneySounds.MAGMA_GIANT_HURT;
 	}
 
 	@Override
-	public SoundEvent setDeathSound() {
+	public SoundEvent getDeathSound() {
 		return JourneySounds.MAGMA_GIANT_HURT;
 	}
 
 	@Override
-	public Item getItemDropped() {
+	public Item getDropItem() {
 		return null;
 	}
 	

--- a/main/java/net/journey/entity/mob/overworld/EntitySmallHongo.java
+++ b/main/java/net/journey/entity/mob/overworld/EntitySmallHongo.java
@@ -4,6 +4,7 @@ import net.journey.JourneySounds;
 import net.journey.entity.MobStats;
 import net.minecraft.init.Blocks;
 import net.minecraft.item.Item;
+import net.minecraft.util.DamageSource;
 import net.minecraft.util.SoundEvent;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
@@ -29,17 +30,17 @@ public class EntitySmallHongo extends EntityModMob {
 	}
 
 	@Override
-	public SoundEvent setLivingSound() {
+	public SoundEvent getAmbientSound() {
 		return JourneySounds.SMALL_HONGO;
 	}
 
 	@Override
-	public SoundEvent setHurtSound() {
+	public SoundEvent getHurtSound(DamageSource sourceIn) {
 		return JourneySounds.SMALL_HONGO_HURT;
 	}
 
 	@Override
-	public SoundEvent setDeathSound() {
+	public SoundEvent getDeathSound() {
 		return JourneySounds.SMALL_HONGO_HURT;
 	}
 
@@ -53,7 +54,7 @@ public class EntitySmallHongo extends EntityModMob {
 	}
 
 	@Override
-	public Item getItemDropped() {
+	public Item getDropItem() {
 		return SlayerAPI.toItem(Blocks.BROWN_MUSHROOM);
 	}
 }

--- a/main/java/net/journey/entity/mob/overworld/EntitySpectre.java
+++ b/main/java/net/journey/entity/mob/overworld/EntitySpectre.java
@@ -8,6 +8,7 @@ import net.minecraft.entity.passive.EntityChicken;
 import net.minecraft.inventory.EntityEquipmentSlot;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
+import net.minecraft.util.DamageSource;
 import net.minecraft.util.SoundEvent;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
@@ -84,22 +85,22 @@ public class EntitySpectre extends EntityModMob {
 	}
 
 	@Override
-	public SoundEvent setLivingSound() {
+	public SoundEvent getAmbientSound() {
 		return JourneySounds.WRAITH;
 	}
 
 	@Override
-	public SoundEvent setHurtSound() {
+	public SoundEvent getHurtSound(DamageSource sourceIn) {
 		return JourneySounds.WRAITH_HURT;
 	}
 
 	@Override
-	public SoundEvent setDeathSound() {
+	public SoundEvent getDeathSound() {
 		return JourneySounds.WRAITH_DEATH;
 	}
 
 	@Override
-	public Item getItemDropped() {
+	public Item getDropItem() {
 		return JourneyItems.demonicBone;
 		
 	}

--- a/main/java/net/journey/entity/mob/overworld/EntitySpyclops.java
+++ b/main/java/net/journey/entity/mob/overworld/EntitySpyclops.java
@@ -5,6 +5,7 @@ import net.journey.JourneySounds;
 import net.journey.entity.MobStats;
 import net.minecraft.init.Blocks;
 import net.minecraft.item.Item;
+import net.minecraft.util.DamageSource;
 import net.minecraft.util.SoundEvent;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
@@ -40,22 +41,22 @@ public class EntitySpyclops extends EntityModMob {
 	}
 
 	@Override
-	public SoundEvent setLivingSound() {
+	public SoundEvent getAmbientSound() {
 		return JourneySounds.SPYCLOPS;
 	}
 
 	@Override
-	public SoundEvent setHurtSound() {
+	public SoundEvent getHurtSound(DamageSource sourceIn) {
 		return JourneySounds.SPYCLOPS;
 	}
 
 	@Override
-	public SoundEvent setDeathSound() {
+	public SoundEvent getDeathSound() {
 		return JourneySounds.SPYCLOPS_HURT;
 	}
 
 	@Override
-	public Item getItemDropped() {
+	public Item getDropItem() {
 		return JourneyItems.spyclopseEye;
 	}
 }

--- a/main/java/net/journey/entity/mob/overworld/EntitySwampFly.java
+++ b/main/java/net/journey/entity/mob/overworld/EntitySwampFly.java
@@ -14,6 +14,7 @@ import net.minecraft.init.Items;
 import net.minecraft.inventory.EntityEquipmentSlot;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
+import net.minecraft.util.DamageSource;
 import net.minecraft.util.EnumHand;
 import net.minecraft.util.SoundEvent;
 import net.minecraft.util.math.AxisAlignedBB;
@@ -51,17 +52,17 @@ public class EntitySwampFly extends EntityModFlying {
 	}
 
 	@Override
-	public SoundEvent setLivingSound() {
+	public SoundEvent getAmbientSound() {
 		return JourneySounds.EMPTY;
 	}
 
 	@Override
-	public SoundEvent setHurtSound() {
+	public SoundEvent getHurtSound(DamageSource sourceIn) {
 		return JourneySounds.EMPTY;
 	}
 
 	@Override
-	public SoundEvent setDeathSound() {
+	public SoundEvent getDeathSound() {
 		return JourneySounds.EMPTY;
 	}
 
@@ -110,7 +111,7 @@ public class EntitySwampFly extends EntityModFlying {
 	}
 
 	@Override
-	public Item getItemDropped() {
+	public Item getDropItem() {
 		return null;
 	}
 

--- a/main/java/net/journey/entity/mob/overworld/EntityTurducken.java
+++ b/main/java/net/journey/entity/mob/overworld/EntityTurducken.java
@@ -5,6 +5,7 @@ import net.journey.JourneySounds;
 import net.journey.entity.MobStats;
 import net.minecraft.init.Blocks;
 import net.minecraft.item.Item;
+import net.minecraft.util.DamageSource;
 import net.minecraft.util.SoundEvent;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
@@ -27,22 +28,22 @@ public class EntityTurducken extends EntityPeacefullUntillAttacked {
 	}
 
 	@Override
-	public SoundEvent setLivingSound() {
+	public SoundEvent getAmbientSound() {
 		return JourneySounds.BIRD;
 	}
 
 	@Override
-	public SoundEvent setHurtSound() {
+	public SoundEvent getHurtSound(DamageSource sourceIn) {
 		return JourneySounds.BIRD_HURT;
 	}
 
 	@Override
-	public SoundEvent setDeathSound() {
+	public SoundEvent getDeathSound() {
 		return JourneySounds.BIRD_DEATH;
 	}
 
 	@Override
-	public Item getItemDropped() {
+	public Item getDropItem() {
 		return JourneyItems.rocMeat;
 	}
 

--- a/main/java/net/journey/entity/mob/overworld/EntityWraith.java
+++ b/main/java/net/journey/entity/mob/overworld/EntityWraith.java
@@ -8,6 +8,7 @@ import net.minecraft.entity.passive.EntityChicken;
 import net.minecraft.inventory.EntityEquipmentSlot;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
+import net.minecraft.util.DamageSource;
 import net.minecraft.util.EnumHand;
 import net.minecraft.util.SoundEvent;
 import net.minecraft.util.math.BlockPos;
@@ -80,22 +81,22 @@ public class EntityWraith extends EntityModMob {
     }
 
 	@Override
-	public SoundEvent setLivingSound() {
+	public SoundEvent getAmbientSound() {
 		return JourneySounds.WRAITH;
 	}
 
 	@Override
-	public SoundEvent setHurtSound() {
+	public SoundEvent getHurtSound(DamageSource sourceIn) {
 		return JourneySounds.WRAITH_HURT;
 	}
 
 	@Override
-	public SoundEvent setDeathSound() {
+	public SoundEvent getDeathSound() {
 		return JourneySounds.WRAITH_DEATH;
 	}
 
 	@Override
-	public Item getItemDropped() {
+	public Item getDropItem() {
 		return JourneyItems.demonicBone;
 		
 	}

--- a/main/java/net/journey/entity/mob/overworld/cold/EntityBlizzard.java
+++ b/main/java/net/journey/entity/mob/overworld/cold/EntityBlizzard.java
@@ -253,23 +253,4 @@ public class EntityBlizzard extends EntityModMob {
 		return 60;
 	}
 
-	@Override
-	public SoundEvent setLivingSound() {
-		return JourneySounds.EMPTY;
-	}
-
-	@Override
-	public SoundEvent setHurtSound() {
-		return JourneySounds.EMPTY;
-	}
-
-	@Override
-	public SoundEvent setDeathSound() {
-		return JourneySounds.EMPTY;
-	}
-
-	@Override
-	public Item getItemDropped() {
-		return Items.SNOWBALL;
-	}
 }

--- a/main/java/net/journey/entity/mob/overworld/jungle/EntityJungleGolem.java
+++ b/main/java/net/journey/entity/mob/overworld/jungle/EntityJungleGolem.java
@@ -79,22 +79,22 @@ public class EntityJungleGolem extends EntityModMob{
     }
 	
 	@Override
-	public SoundEvent setLivingSound() {
+	public SoundEvent getAmbientSound() {
 		return JourneySounds.BUSH;
 	}
 
 	@Override
-	public SoundEvent setHurtSound() {
+	public SoundEvent getHurtSound(DamageSource sourceIn) {
 		return JourneySounds.BUSH_HURT;
 	}
 
 	@Override
-	public SoundEvent setDeathSound() {
+	public SoundEvent getDeathSound() {
 		return JourneySounds.BUSH_DEATH;
 	}
 	
 	@Override
-	public Item getItemDropped() {
+	public Item getDropItem() {
 		return null;
 	}
 	

--- a/main/java/net/journey/entity/mob/overworld/jungle/EntityJungleSpider.java
+++ b/main/java/net/journey/entity/mob/overworld/jungle/EntityJungleSpider.java
@@ -272,22 +272,7 @@ public class EntityJungleSpider extends EntityModMob {
 	}
 
 	@Override
-	public SoundEvent setLivingSound() {
-		return null;
-	}
-
-	@Override
-	public SoundEvent setHurtSound() {
-		return null;
-	}
-
-	@Override
-	public SoundEvent setDeathSound() {
-		return null;
-	}
-
-	@Override
-	public Item getItemDropped() {
+	public Item getDropItem() {
 		return null;
 	}
 }

--- a/main/java/net/journey/entity/mob/overworld/jungle/EntityJungleTurtle.java
+++ b/main/java/net/journey/entity/mob/overworld/jungle/EntityJungleTurtle.java
@@ -8,6 +8,7 @@ import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.SharedMonsterAttributes;
 import net.minecraft.item.Item;
 import net.minecraft.potion.PotionEffect;
+import net.minecraft.util.DamageSource;
 import net.minecraft.util.SoundEvent;
 import net.minecraft.util.math.MathHelper;
 import net.minecraft.world.World;
@@ -51,22 +52,22 @@ public class EntityJungleTurtle extends EntityModMob {
 	}
 
 	@Override
-	public SoundEvent setLivingSound() {
+	public SoundEvent getAmbientSound() {
 		return JourneySounds.SMALL_HONGO;
 	}
 
 	@Override
-	public SoundEvent setHurtSound() {
+	public SoundEvent getHurtSound(DamageSource sourceIn) {
 		return JourneySounds.SMALL_HONGO_HURT;
 	}
 
 	@Override
-	public SoundEvent setDeathSound() {
+	public SoundEvent getDeathSound() {
 		return JourneySounds.SMALL_HONGO_HURT;
 	}
 	
 	@Override
-	public Item getItemDropped() {
+	public Item getDropItem() {
 		return null;
 	}
 }

--- a/main/java/net/journey/entity/mob/overworld/underground/EntityBlueHonglow.java
+++ b/main/java/net/journey/entity/mob/overworld/underground/EntityBlueHonglow.java
@@ -40,22 +40,22 @@ public class EntityBlueHonglow extends EntityModMob {
 	}
 
 	@Override
-	public SoundEvent setLivingSound() {
+	public SoundEvent getAmbientSound() {
 		return JourneySounds.HONGO;
 	}
 
 	@Override
-	public SoundEvent setHurtSound() {
+	public SoundEvent getHurtSound(DamageSource sourceIn) {
 		return JourneySounds.HONGO_HURT;
 	}
 
 	@Override
-	public SoundEvent setDeathSound() {
+	public SoundEvent getDeathSound() {
 		return JourneySounds.HONGO_HURT;
 	}
 
 	@Override
-	public Item getItemDropped() {
+	public Item getDropItem() {
 		return null;
 
 	}

--- a/main/java/net/journey/entity/mob/overworld/underground/EntityCaveMage.java
+++ b/main/java/net/journey/entity/mob/overworld/underground/EntityCaveMage.java
@@ -86,17 +86,17 @@ public class EntityCaveMage extends EntityModMob implements IRangedAttackMob {
 	}
 
 	@Override
-	public SoundEvent setLivingSound() {
+	public SoundEvent getAmbientSound() {
 		return JourneySounds.INSECTO;
 	}
 
 	@Override
-	public SoundEvent setHurtSound() {
+	public SoundEvent getHurtSound(DamageSource sourceIn) {
 		return JourneySounds.INSECTO_HURT;
 	}
 
 	@Override
-	public SoundEvent setDeathSound() {
+	public SoundEvent getDeathSound() {
 		return JourneySounds.INSECTO_HURT;
 	}
 
@@ -116,7 +116,7 @@ public class EntityCaveMage extends EntityModMob implements IRangedAttackMob {
 	}
 
 	@Override
-	public Item getItemDropped() {
+	public Item getDropItem() {
 		return null;
 	}
 

--- a/main/java/net/journey/entity/mob/overworld/underground/EntityCaveling.java
+++ b/main/java/net/journey/entity/mob/overworld/underground/EntityCaveling.java
@@ -33,22 +33,22 @@ public class EntityCaveling extends EntityModMob {
 	}
 
 	@Override
-	public SoundEvent setLivingSound() {
+	public SoundEvent getAmbientSound() {
 		return JourneySounds.CAVE_MOB;
 	}
 
 	@Override
-	public SoundEvent setHurtSound() {
+	public SoundEvent getHurtSound(DamageSource sourceIn) {
 		return JourneySounds.ROCK;
 	}
 
 	@Override
-	public SoundEvent setDeathSound() {
+	public SoundEvent getDeathSound() {
 		return JourneySounds.BASE_MOB_HURT;
 	}
 
 	@Override
-	public Item getItemDropped() {
+	public Item getDropItem() {
 		return SlayerAPI.toItem(Blocks.STONE);
 
 	}

--- a/main/java/net/journey/entity/mob/overworld/underground/EntityCavurn.java
+++ b/main/java/net/journey/entity/mob/overworld/underground/EntityCavurn.java
@@ -92,17 +92,17 @@ public class EntityCavurn extends EntityModMob implements IRangedAttackMob {
 	}
 
 	@Override
-	public SoundEvent setLivingSound() {
+	public SoundEvent getAmbientSound() {
 		return JourneySounds.BASE_MOB_HURT;
 	}
 
 	@Override
-	public SoundEvent setHurtSound() {
+	public SoundEvent getHurtSound(DamageSource sourceIn) {
 		return JourneySounds.ROCK;
 	}
 
 	@Override
-	public SoundEvent setDeathSound() {
+	public SoundEvent getDeathSound() {
 		return JourneySounds.CAVE_MOB;
 	}
 	
@@ -122,7 +122,7 @@ public class EntityCavurn extends EntityModMob implements IRangedAttackMob {
 	}
 	
 	@Override
-	public Item getItemDropped() {
+	public Item getDropItem() {
 		return null;
 	}
 	

--- a/main/java/net/journey/entity/mob/overworld/underground/EntityGreenHonglow.java
+++ b/main/java/net/journey/entity/mob/overworld/underground/EntityGreenHonglow.java
@@ -40,22 +40,22 @@ public class EntityGreenHonglow extends EntityModMob {
 	}
 
 	@Override
-	public SoundEvent setLivingSound() {
+	public SoundEvent getAmbientSound() {
 		return JourneySounds.HONGO;
 	}
 
 	@Override
-	public SoundEvent setHurtSound() {
+	public SoundEvent getHurtSound(DamageSource sourceIn) {
 		return JourneySounds.HONGO_HURT;
 	}
 
 	@Override
-	public SoundEvent setDeathSound() {
+	public SoundEvent getDeathSound() {
 		return JourneySounds.HONGO_HURT;
 	}
 
 	@Override
-	public Item getItemDropped() {
+	public Item getDropItem() {
 		return null;
 
 	}

--- a/main/java/net/journey/entity/mob/overworld/underground/EntityHonglow.java
+++ b/main/java/net/journey/entity/mob/overworld/underground/EntityHonglow.java
@@ -40,17 +40,17 @@ public class EntityHonglow extends EntityModMob {
 	}
 
 	@Override
-	public SoundEvent setLivingSound() {
+	public SoundEvent getAmbientSound() {
 		return JourneySounds.HONGO;
 	}
 
 	@Override
-	public SoundEvent setHurtSound() {
+	public SoundEvent getHurtSound(DamageSource sourceIn) {
 		return JourneySounds.HONGO_HURT;
 	}
 
 	@Override
-	public SoundEvent setDeathSound() {
+	public SoundEvent getDeathSound() {
 		return JourneySounds.HONGO_HURT;
 	}
 
@@ -78,7 +78,7 @@ public class EntityHonglow extends EntityModMob {
 	}
 
 	@Override
-	public Item getItemDropped() {
+	public Item getDropItem() {
 		return null;
 	}
 }

--- a/main/java/net/journey/entity/mob/overworld/underground/EntityStonewalker.java
+++ b/main/java/net/journey/entity/mob/overworld/underground/EntityStonewalker.java
@@ -32,22 +32,22 @@ public class EntityStonewalker extends EntityModMob {
 	}
 	
 	@Override
-	public SoundEvent setLivingSound() {
+	public SoundEvent getAmbientSound() {
 		return JourneySounds.ROCK;
 	}
 
 	@Override
-	public SoundEvent setHurtSound() {
+	public SoundEvent getHurtSound(DamageSource sourceIn) {
 		return JourneySounds.CAVE_MOB;
 	}
 
 	@Override
-	public SoundEvent setDeathSound() {
+	public SoundEvent getDeathSound() {
 		return JourneySounds.BASE_MOB_HURT;
 	}
 	
 	@Override
-	public Item getItemDropped() {
+	public Item getDropItem() {
 		return SlayerAPI.toItem(Blocks.STONE);
 
 	}

--- a/main/java/net/journey/entity/mob/pet/EntityEucaHopper.java
+++ b/main/java/net/journey/entity/mob/pet/EntityEucaHopper.java
@@ -214,17 +214,17 @@ public class EntityEucaHopper extends EntityModTameable {
 	}
 
 	@Override
-	public SoundEvent setLivingSound() {
+	public SoundEvent getAmbientSound() {
 		return JourneySounds.HONGO;
 	}
 
 	@Override
-	public SoundEvent setHurtSound() {
+	public SoundEvent getHurtSound(DamageSource sourceIn) {
 		return JourneySounds.TURTLE_HURT;
 	}
 
 	@Override
-	public SoundEvent setDeathSound() {
+	public SoundEvent getDeathSound() {
 		return JourneySounds.TURTLE_HURT;
 	}
 }

--- a/main/java/net/journey/entity/mob/pet/EntityShiverwolf.java
+++ b/main/java/net/journey/entity/mob/pet/EntityShiverwolf.java
@@ -511,18 +511,4 @@ public class EntityShiverwolf extends EntityModTameable {
         return !this.isAngry() && super.canBeLeashedTo(player);
     }
 
-	@Override
-	public SoundEvent setLivingSound() {
-		return JourneySounds.EMPTY;
-	}
-
-	@Override
-	public SoundEvent setHurtSound() {
-		return JourneySounds.EMPTY;
-	}
-
-	@Override
-	public SoundEvent setDeathSound() {
-		return JourneySounds.EMPTY;
-	}
 }

--- a/main/java/net/journey/entity/mob/pet/EntityTameRoc.java
+++ b/main/java/net/journey/entity/mob/pet/EntityTameRoc.java
@@ -259,17 +259,17 @@ public class EntityTameRoc extends EntityModTameable {
 	}
 
 	@Override
-	public SoundEvent setLivingSound() {
+	public SoundEvent getAmbientSound() {
 		return JourneySounds.BIRD;
 	}
 
 	@Override
-	public SoundEvent setHurtSound() {
+	public SoundEvent getHurtSound(DamageSource sourceIn) {
 		return JourneySounds.BIRD_HURT;
 	}
 
 	@Override
-	public SoundEvent setDeathSound() {
+	public SoundEvent getDeathSound() {
 		return JourneySounds.BIRD_DEATH;
 	}
 }

--- a/main/java/net/journey/entity/mob/terrania/mob/EntityPurplian.java
+++ b/main/java/net/journey/entity/mob/terrania/mob/EntityPurplian.java
@@ -152,22 +152,22 @@ public class EntityPurplian extends EntityModMob {
 	}
 
 	@Override
-	public SoundEvent setLivingSound() {
+	public SoundEvent getAmbientSound() {
 		return SoundEvents.ENTITY_BLAZE_AMBIENT;
 	}
 
 	@Override
-	public SoundEvent setHurtSound() {
+	public SoundEvent getHurtSound(DamageSource sourceIn) {
 		return SoundEvents.ENTITY_BLAZE_HURT;
 	}
 
 	@Override
-	public SoundEvent setDeathSound() {
+	public SoundEvent getDeathSound() {
 		return SoundEvents.ENTITY_BLAZE_DEATH;
 	}
 
 	@Override
-	public Item getItemDropped() {
+	public Item getDropItem() {
 		return Items.BLAZE_ROD;
 	}
 

--- a/main/java/net/journey/entity/mob/terrania/mob/EntityTerraScatterer.java
+++ b/main/java/net/journey/entity/mob/terrania/mob/EntityTerraScatterer.java
@@ -5,6 +5,7 @@ import net.journey.JourneySounds;
 import net.journey.entity.MobStats;
 import net.minecraft.init.SoundEvents;
 import net.minecraft.item.Item;
+import net.minecraft.util.DamageSource;
 import net.minecraft.util.SoundEvent;
 import net.minecraft.world.World;
 import net.slayer.api.entity.EntityModMob;
@@ -26,17 +27,17 @@ public class EntityTerraScatterer extends EntityModMob {
 	}
 
 	@Override
-	public SoundEvent setLivingSound() {
+	public SoundEvent getAmbientSound() {
 		return JourneySounds.WRAITH;
 	}
 
 	@Override
-	public SoundEvent setHurtSound() {
+	public SoundEvent getHurtSound(DamageSource sourceIn) {
 		return SoundEvents.ENTITY_CREEPER_HURT;
 	}
 
 	@Override
-	public SoundEvent setDeathSound() {
+	public SoundEvent getDeathSound() {
 		return JourneySounds.WRAITH_DEATH;
 	}
 	
@@ -48,7 +49,7 @@ public class EntityTerraScatterer extends EntityModMob {
 	}
 
 	@Override
-	public Item getItemDropped() {
+	public Item getDropItem() {
 		return null;
 	}
 

--- a/main/java/net/journey/entity/mob/terrania/mob/EntityTerragrow.java
+++ b/main/java/net/journey/entity/mob/terrania/mob/EntityTerragrow.java
@@ -5,6 +5,7 @@ import net.journey.JourneySounds;
 import net.journey.entity.MobStats;
 import net.minecraft.init.SoundEvents;
 import net.minecraft.item.Item;
+import net.minecraft.util.DamageSource;
 import net.minecraft.util.SoundEvent;
 import net.minecraft.world.World;
 import net.slayer.api.entity.EntityModMob;
@@ -26,17 +27,17 @@ public class EntityTerragrow extends EntityModMob {
 	}
 
 	@Override
-	public SoundEvent setLivingSound() {
+	public SoundEvent getAmbientSound() {
 		return JourneySounds.WRAITH;
 	}
 
 	@Override
-	public SoundEvent setHurtSound() {
+	public SoundEvent getHurtSound(DamageSource sourceIn) {
 		return SoundEvents.ENTITY_CREEPER_HURT;
 	}
 
 	@Override
-	public SoundEvent setDeathSound() {
+	public SoundEvent getDeathSound() {
 		return JourneySounds.WRAITH_DEATH;
 	}
 	
@@ -49,7 +50,7 @@ public class EntityTerragrow extends EntityModMob {
 	}
 
 	@Override
-	public Item getItemDropped() {
+	public Item getDropItem() {
 		return null;
 	}
 

--- a/main/java/net/journey/entity/mob/terrania/mob/EntityTerralight.java
+++ b/main/java/net/journey/entity/mob/terrania/mob/EntityTerralight.java
@@ -7,6 +7,7 @@ import net.journey.entity.MobStats;
 import net.minecraft.entity.ai.EntityAIBase;
 import net.minecraft.entity.ai.EntityMoveHelper;
 import net.minecraft.item.Item;
+import net.minecraft.util.DamageSource;
 import net.minecraft.util.SoundEvent;
 import net.minecraft.util.math.AxisAlignedBB;
 import net.minecraft.util.math.MathHelper;
@@ -37,22 +38,22 @@ public class EntityTerralight extends EntityModFlying {
 	}
 
 	@Override
-	public SoundEvent setLivingSound() {
+	public SoundEvent getAmbientSound() {
 		return JourneySounds.EMPTY;
 	}
 
 	@Override
-	public SoundEvent setHurtSound() {
+	public SoundEvent getHurtSound(DamageSource sourceIn) {
 		return JourneySounds.EMPTY;
 	}
 
 	@Override
-	public SoundEvent setDeathSound() {
+	public SoundEvent getDeathSound() {
 		return JourneySounds.EMPTY;
 	}
 	
 	@Override
-	public Item getItemDropped() {
+	public Item getDropItem() {
 		return null;
 	}
 	

--- a/main/java/net/journey/entity/mob/terrania/mob/EntityTerrashroom.java
+++ b/main/java/net/journey/entity/mob/terrania/mob/EntityTerrashroom.java
@@ -4,6 +4,7 @@ import net.journey.JourneyItems;
 import net.journey.JourneySounds;
 import net.journey.entity.MobStats;
 import net.minecraft.item.Item;
+import net.minecraft.util.DamageSource;
 import net.minecraft.util.SoundEvent;
 import net.minecraft.world.World;
 import net.slayer.api.entity.EntityModMob;
@@ -27,17 +28,17 @@ public class EntityTerrashroom extends EntityModMob {
 	}
 
 	@Override
-	public SoundEvent setLivingSound() {
+	public SoundEvent getAmbientSound() {
 		return JourneySounds.HONGO;
 	}
 
 	@Override
-	public SoundEvent setHurtSound() {
+	public SoundEvent getHurtSound(DamageSource sourceIn) {
 		return JourneySounds.HONGO_HURT;
 	}
 
 	@Override
-	public SoundEvent setDeathSound() {
+	public SoundEvent getDeathSound() {
 		return JourneySounds.HONGO_HURT;
 	}
 
@@ -49,7 +50,7 @@ public class EntityTerrashroom extends EntityModMob {
 	}
 
 	@Override
-	public Item getItemDropped() {
+	public Item getDropItem() {
 		return null;
 	}
 }

--- a/main/java/net/journey/entity/mob/terrania/mob/EntityTerraslug.java
+++ b/main/java/net/journey/entity/mob/terrania/mob/EntityTerraslug.java
@@ -4,6 +4,7 @@ import net.journey.JourneyItems;
 import net.journey.JourneySounds;
 import net.journey.entity.MobStats;
 import net.minecraft.item.Item;
+import net.minecraft.util.DamageSource;
 import net.minecraft.util.SoundEvent;
 import net.minecraft.world.World;
 import net.slayer.api.entity.EntityModMob;
@@ -27,22 +28,22 @@ public class EntityTerraslug extends EntityModMob {
 	}
 	
 	@Override
-	public SoundEvent setLivingSound() {
+	public SoundEvent getAmbientSound() {
 		return JourneySounds.TERRA_SLUG;
 	}
 
 	@Override
-	public SoundEvent setHurtSound() {
+	public SoundEvent getHurtSound(DamageSource sourceIn) {
 		return JourneySounds.TERRA_SLUG_HURT;
 	}
 
 	@Override
-	public SoundEvent setDeathSound() {
+	public SoundEvent getDeathSound() {
 		return JourneySounds.TERRA_SLUG_DEATH;
 	}
 
 	@Override
-	public Item getItemDropped() {
+	public Item getDropItem() {
 		return JourneyItems.slugSlime;
 	}
 	

--- a/main/java/net/journey/items/ItemGun.java
+++ b/main/java/net/journey/items/ItemGun.java
@@ -44,6 +44,8 @@ public class ItemGun extends ItemMod {
 		if(!world.isRemote) {
 			if(this == JourneyItems.chaosCannon) {
 				if(mana.useEssence(2)) {
+					System.out.println(player);
+					System.out.println(mana.getEssenceValue());
 					JourneySounds.playSound(JourneySounds.CANNON, world, player);
 					EntityBouncingProjectile bouncing = new EntityBouncingProjectile(world, player, damage, 4);
 					bouncing.shoot(player, player.rotationPitch, player.rotationYaw, 0.0F, 1.0F, 1.0F);

--- a/main/java/net/journey/items/ItemTeleport.java
+++ b/main/java/net/journey/items/ItemTeleport.java
@@ -67,6 +67,8 @@ public class ItemTeleport extends ItemMod {
 				if (var26 == 5) ++var23;                
 
 				if(mana.useEssence(5)) {
+					System.out.println(player);
+					System.out.println(mana.getEssenceValue());
 					player.getLook(1);
 					this.teleportTo(player, worldIn, var23, var24, var25);
 				}

--- a/main/java/net/slayer/api/entity/EntityEssenceBoss.java
+++ b/main/java/net/slayer/api/entity/EntityEssenceBoss.java
@@ -26,7 +26,7 @@ public abstract class EntityEssenceBoss extends EntityModMob implements IEssence
 	}
 	
 	@Override
-	public SoundEvent setDeathSound() {
+	public SoundEvent getDeathSound() {
 		return JourneySounds.BOSS_DEATH;
     }
     

--- a/main/java/net/slayer/api/entity/EntityModFlying.java
+++ b/main/java/net/slayer/api/entity/EntityModFlying.java
@@ -36,37 +36,10 @@ public abstract class EntityModFlying extends EntityFlying {
 	public double setKnockbackResistance() {return MobStats.knockBackResistance;}
 
 	public abstract double setMaxHealth(MobStats s);
-	public abstract SoundEvent setLivingSound();
-	public abstract SoundEvent setHurtSound();
-	public abstract SoundEvent setDeathSound();
-	public abstract Item getItemDropped();
 
-	@Override
-	protected Item getDropItem() {
-		return getItemDropped();
-	}
-	
 	@Override
 	protected void dropFewItems(boolean b, int j) {
 		for(int i = 0; i < 1 + rand.nextInt(1); i++)
-			this.dropItem(getItemDropped(), 1);
-	}
-
-	@Override
-	protected SoundEvent getAmbientSound() {
-		super.getAmbientSound();
-		return setLivingSound();
-	}
-
-	@Override
-	protected SoundEvent getHurtSound(DamageSource d) {
-		super.getHurtSound(d);
-		return setHurtSound();
-	}
-
-	@Override
-	protected SoundEvent getDeathSound() {
-		super.getDeathSound();
-		return setDeathSound();
+			this.dropItem(getDropItem(), 1);
 	}
 }

--- a/main/java/net/slayer/api/entity/EntityModMob.java
+++ b/main/java/net/slayer/api/entity/EntityModMob.java
@@ -64,45 +64,12 @@ public abstract class EntityModMob extends EntityMob {
 
 	public abstract double setAttackDamage(MobStats s);
 	public abstract double setMaxHealth(MobStats s);
-	public abstract SoundEvent setLivingSound();
-	public abstract SoundEvent setHurtSound();
-	public abstract SoundEvent setDeathSound();
-	public abstract Item getItemDropped();
 
-	@Override
-	protected Item getDropItem() {
-		return getItemDropped();
-	}
-	
-	@Override
-	protected void dropFewItems(boolean b, int j) {
-		for(int i = 0; i < 1 + rand.nextInt(1); i++)
-			this.dropItem(getItemDropped(), 1);
-	}
-	
 	@Override
     protected void playStepSound(BlockPos pos, Block blockIn) {
 		 this.playSound(SoundEvents.ENTITY_WOLF_STEP, 0.15F, 1.0F);
     }
 
-	@Override
-	protected SoundEvent getAmbientSound() {
-		super.getAmbientSound();
-		return setLivingSound();
-	}
-
-	@Override
-	protected SoundEvent getHurtSound(DamageSource d) {
-		super.getHurtSound(d);
-		return setHurtSound();
-	}
-
-	@Override
-	protected SoundEvent getDeathSound() {
-		super.getDeathSound();
-		return setDeathSound();
-	}
-	
 	@Override
 	public boolean getCanSpawnHere() {
 		return world.getDifficulty() != EnumDifficulty.PEACEFUL && this.world.checkNoEntityCollision(this.getEntityBoundingBox()) && this.world.getCollisionBoxes(this, this.getEntityBoundingBox()).isEmpty() && !this.world.containsAnyLiquid(this.getEntityBoundingBox());

--- a/main/java/net/slayer/api/entity/EntityModTameable.java
+++ b/main/java/net/slayer/api/entity/EntityModTameable.java
@@ -54,28 +54,6 @@ public abstract class EntityModTameable extends EntityTameable {
 	public double getFollowRange(){return getEntityAttribute(SharedMonsterAttributes.FOLLOW_RANGE).getAttributeValue();}
 	public double getKnockbackResistance(){return getEntityAttribute(SharedMonsterAttributes.KNOCKBACK_RESISTANCE).getAttributeValue();}
 
-	public abstract SoundEvent setLivingSound();
-	public abstract SoundEvent setHurtSound();
-	public abstract SoundEvent setDeathSound();
-
-	@Override
-	protected SoundEvent getAmbientSound() {
-		super.getAmbientSound();
-		return setLivingSound();
-	}
-
-	@Override
-	protected SoundEvent getHurtSound(DamageSource d) {
-		super.getHurtSound(d);
-		return setHurtSound();
-	}
-
-	@Override
-	protected SoundEvent getDeathSound() {
-		super.getDeathSound();
-		return setDeathSound();
-	}
-
 	@Override
 	protected void entityInit() {
 		super.entityInit();

--- a/main/java/net/slayer/api/entity/EntityModWaterMob.java
+++ b/main/java/net/slayer/api/entity/EntityModWaterMob.java
@@ -36,37 +36,10 @@ public abstract class EntityModWaterMob extends EntityWaterMob {
 	public double setKnockbackResistance() {return MobStats.knockBackResistance;}
 
 	public abstract double setMaxHealth(MobStats s);
-	public abstract SoundEvent setLivingSound();
-	public abstract SoundEvent setHurtSound();
-	public abstract SoundEvent setDeathSound();
-	public abstract Item getItemDropped();
-
-	@Override
-	protected Item getDropItem() {
-		return getItemDropped();
-	}
 	
 	@Override
 	protected void dropFewItems(boolean b, int j) {
 		for(int i = 0; i < 1 + rand.nextInt(1); i++)
-			this.dropItem(getItemDropped(), 1);
-	}
-
-	@Override
-	protected SoundEvent getAmbientSound() {
-		super.getAmbientSound();
-		return setLivingSound();
-	}
-
-	@Override
-	protected SoundEvent getHurtSound(DamageSource d) {
-		super.getHurtSound(d);
-		return setHurtSound();
-	}
-
-	@Override
-	protected SoundEvent getDeathSound() {
-		super.getDeathSound();
-		return setDeathSound();
+			this.dropItem(getDropItem(), 1);
 	}
 }


### PR DESCRIPTION
Currently EntityModMob (mob base class) had this method for setting its sounds
```
@Override
protected SoundEvent getAmbientSound() {
	super.getAmbientSound();
	return setLivingSound();
}
```
setLivingSound is here:
https://github.com/TheSlayerMC/Journey-1.12/blob/f777ff6ed6671ac4f683318225d439bdf21b04db/main/java/net/slayer/api/entity/EntityModMob.java#L67

Set methods are supposed to take a parameter and return nothing, but, the set method in this class takes nothing and returns something which is what a get method is supposed to do. Seems kind of pointless when you can just override getLivingSound for each specific mob, which takes the same amount of time as coding a setLivingSound, etc. for every mob (as is done now), but is less confusing.

Here's some other examples of mods just overriding the getWhateverSound methods in the individual mob class, instead of overriding it in the base class to use output from "setWhateverSound" methods and then overriding the setWhateverSound methods in the individual mob class:
https://github.com/TeamTwilight/twilightforest/blob/a565a89d851feda91c5648da28f01285dcaf8ef1/src/main/java/twilightforest/entity/EntityTFYeti.java#L210
https://github.com/Tslat/Advent-Of-Ascension/blob/e9f06628945a5c2ed44f153354d13456a1de4ad6/source/entity/mobs/shyrelands/EntityArcworm.java#L49
https://github.com/vadis365/TheErebus/blob/5a0ea223536d298c1b7891a3b8a56a6b93950d29/src/main/java/erebus/entity/EntityBlackWidow.java#L149

Anyway in this PR basically I just completely cut out the "setLivingSound" or whatever methods and make every mob just override getWhateverSound(). If there's something I'm missing let me know lol

And yes, it still works, tested it on various mobs and they all make the proper sounds.

